### PR TITLE
docs: add PR template and contributing guide

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+## What this changes
+
+
+## Checklist
+
+- [ ] Ran `pytest -v -m "not slow"` locally — all tests pass
+- [ ] Tested on a real Mac with the accelerator running
+- [ ] No unrelated changes bundled in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+## Before you push
+
+```bash
+pytest -v -m "not slow"
+```
+
+All tests must pass. CI runs the same suite — if it fails there, the PR won't be merged.
+
+## What to test
+
+- `pytest` covers compose template validation, regex patterns, config parsing, and fresh-install regressions
+- If your change touches the ffmpeg wrapper, dashboard, or worker startup, test on a real Mac with the accelerator running
+- ML changes go through the [upstream repo](https://github.com/sebastianfredette/immich-ml-metal)
+
+## PR guidelines
+
+- One concern per PR
+- Keep diffs small — under 200 lines is ideal
+- Update CHANGELOG.md if user-facing


### PR DESCRIPTION
Adds checklist for contributors to run tests locally before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)