### PR TITLE
Support authenticated Redis (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Features
+- **Support authenticated Redis (#56)**. The native worker now forwards `REDIS_PASSWORD` and `REDIS_USERNAME` to Immich, so deployments that require a Redis password (e.g. the TrueNAS Immich app) or ACL user+password auth work. Remote setup prompts for the username and password, the manual config template includes `redis_username` / `redis_password` fields, and the preflight Redis check authenticates via `REDISCLI_AUTH` (and `--user` for ACL).
+
 ## 1.5.3 — 2026-06-03
 
 ### Fixes

--- a/immich_accelerator/__main__.py
+++ b/immich_accelerator/__main__.py
@@ -756,14 +756,25 @@ def _preflight_env_health(config: dict) -> bool:
     # Redis connectivity — try a real PING if redis-cli is available.
     redis_host = config.get("redis_hostname", "localhost")
     redis_port = config.get("redis_port", "6379")
+    redis_username = config.get("redis_username", "")
+    redis_password = config.get("redis_password", "")
     redis_cli = shutil.which("redis-cli")
     if redis_cli:
         try:
+            # REDISCLI_AUTH keeps the password off the process list.
+            redis_env = os.environ.copy()
+            if redis_password:
+                redis_env["REDISCLI_AUTH"] = redis_password
+            redis_cmd = [redis_cli, "-h", redis_host, "-p", str(redis_port)]
+            if redis_username:
+                redis_cmd += ["--user", redis_username]
+            redis_cmd.append("PING")
             result = subprocess.run(
-                [redis_cli, "-h", redis_host, "-p", str(redis_port), "PING"],
+                redis_cmd,
                 capture_output=True,
                 text=True,
                 timeout=5,
+                env=redis_env,
             )
             if "PONG" not in (result.stdout or ""):
                 err = (result.stderr or result.stdout or "").strip()
@@ -2559,6 +2570,8 @@ def _setup_remote(args):
     db_name = prompt("Database name", "immich")
     redis_hostname = prompt("Redis host", db_hostname)
     redis_port = prompt("Redis port", "6379")
+    redis_username = prompt("Redis username [blank if none]", "")
+    redis_password = getpass.getpass("  Redis password [blank if none]: ").strip()
 
     # Probe Docker's view of the media root so we can surface mismatch
     # up-front rather than when thumbnails 404 (issue #19). Requires
@@ -2666,6 +2679,8 @@ def _setup_remote(args):
         "db_name": db_name,
         "redis_hostname": redis_hostname,
         "redis_port": redis_port,
+        "redis_username": redis_username,
+        "redis_password": redis_password,
         "upload_mount": upload_mount,
         "ffmpeg_path": ffmpeg_path,
         "ml_dir": str(ml_dir) if ml_dir else None,
@@ -2703,6 +2718,8 @@ def _setup_manual(_args):
         "db_name": "immich",
         "redis_hostname": "YOUR_REDIS_HOST",
         "redis_port": "6379",
+        "redis_username": "",
+        "redis_password": "",
         "upload_mount": "/path/to/immich/upload",
         "ffmpeg_path": "/opt/homebrew/bin/ffmpeg",
         "ml_dir": str(Path(__file__).parent.parent / "ml"),
@@ -3103,6 +3120,14 @@ def cmd_start(args):
             "PATH": str(Path(node).parent) + ":" + os.environ.get("PATH", ""),
         }
     )
+
+    # Forward Redis credentials only when set — an empty password makes
+    # ioredis send AUTH to a password-less Redis, which errors (issue #56).
+    # REDIS_USERNAME enables ACL (user + password) auth on Redis 6+.
+    if config.get("redis_username"):
+        worker_env["REDIS_USERNAME"] = config["redis_username"]
+    if config.get("redis_password"):
+        worker_env["REDIS_PASSWORD"] = config["redis_password"]
 
     if config.get("upload_mount"):
         worker_env["IMMICH_MEDIA_LOCATION"] = config["upload_mount"]

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -224,7 +224,13 @@ class TestConfigManagement:
 
 
 class TestRedisAuth:
-    def test_manual_template_includes_redis_credentials(self, tmp_data_dir):
+    def test_manual_template_includes_redis_credentials(self, tmp_data_dir, monkeypatch):
+        # _setup_manual probes local tools after writing the template; stub
+        # that out so the test doesn't depend on brew/node being installed.
+        monkeypatch.setattr(
+            "immich_accelerator.__main__._check_local_tools",
+            lambda: ("/usr/bin/node", None, None),
+        )
         _setup_manual(None)
         config = json.loads(tmp_data_dir["config_file"].read_text())
         assert "redis_username" in config

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -34,6 +34,7 @@ from immich_accelerator.__main__ import (
     cmd_status,
     cmd_logs,
     start_service,
+    _setup_manual,
     DATA_DIR,
     CONFIG_FILE,
     PID_DIR,
@@ -215,6 +216,67 @@ class TestConfigManagement:
         config_file.write_text("not json at all")
         with pytest.raises(json.JSONDecodeError):
             load_config()
+
+
+# ---------------------------------------------------------------------------
+# Authenticated Redis (issue #56)
+# ---------------------------------------------------------------------------
+
+
+class TestRedisAuth:
+    def test_manual_template_includes_redis_credentials(self, tmp_data_dir):
+        _setup_manual(None)
+        config = json.loads(tmp_data_dir["config_file"].read_text())
+        assert "redis_username" in config
+        assert "redis_password" in config
+
+    def _run_preflight(self, monkeypatch, config):
+        """Run _preflight_env_health, capturing the redis-cli PING.
+
+        Only redis-cli is on PATH; every other probe is neutralized so
+        the test exercises the Redis auth path regardless of host state.
+        Returns (cmd, env) of the captured redis-cli invocation.
+        """
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            if cmd and "redis-cli" in cmd[0]:
+                captured["cmd"] = cmd
+                captured["env"] = kwargs.get("env", {})
+            return MagicMock(stdout="PONG", stderr="", returncode=0)
+
+        monkeypatch.setattr(
+            "immich_accelerator.__main__.shutil.which",
+            lambda name: "/bin/redis-cli" if name == "redis-cli" else None,
+        )
+        monkeypatch.setattr("immich_accelerator.__main__.subprocess.run", fake_run)
+        monkeypatch.setattr(
+            "immich_accelerator.__main__.socket.create_connection",
+            lambda *a, **k: MagicMock(),
+        )
+        from immich_accelerator.__main__ import _preflight_env_health
+
+        _preflight_env_health(config)
+        return captured.get("cmd", []), captured.get("env", {})
+
+    def test_preflight_uses_auth_when_password_set(self, monkeypatch, sample_config):
+        _cmd, env = self._run_preflight(
+            monkeypatch, {**sample_config, "redis_password": "s3cret"}
+        )
+        assert env.get("REDISCLI_AUTH") == "s3cret"
+
+    def test_preflight_omits_auth_when_no_password(self, monkeypatch, sample_config):
+        cmd, env = self._run_preflight(monkeypatch, sample_config)
+        assert "REDISCLI_AUTH" not in env
+        assert "--user" not in cmd
+
+    def test_preflight_passes_username_for_acl(self, monkeypatch, sample_config):
+        cmd, env = self._run_preflight(
+            monkeypatch,
+            {**sample_config, "redis_username": "immich", "redis_password": "s3cret"},
+        )
+        assert cmd[cmd.index("--user") + 1] == "immich"
+        assert env.get("REDISCLI_AUTH") == "s3cret"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this changes

Adds support for authenticated Redis. The native worker previously forwarded only `REDIS_HOSTNAME` and `REDIS_PORT`, so any Immich deployment requiring Redis auth could not use the accelerator. The **TrueNAS Immich app** mandates a Redis password, which blocked that setup entirely.

- **Worker**: forward `REDIS_PASSWORD` and `REDIS_USERNAME` to Immich in `cmd_start`, each only when set — an empty password would make ioredis send `AUTH` to a password-less Redis and error. `REDIS_USERNAME` enables ACL (user + password) auth on Redis 6+.
- **Remote setup**: prompt for the Redis username and password and persist them.
- **Manual template**: add `redis_username` / `redis_password` fields.
- **Preflight**: the Redis `PING` health check now authenticates via `REDISCLI_AUTH` (keeps the password off the process list) and `--user` for ACL.

All env vars match what Immich's own code already reads (`REDIS_USERNAME`, `REDIS_PASSWORD`), so this is a pure passthrough — no behavior change for password-less Redis.

Closes #56

## Checklist

- [x] Ran `pytest -v -m "not slow"` locally — all tests pass (159 passed, 1 skipped; adds `TestRedisAuth`)
- [x] Tested on a real Mac with the accelerator running — end-to-end on a TrueNAS split deployment (MacBook Air M5 native worker, password-protected Redis on the NAS, `requirepass`). The worker authenticates to Redis and processes the job queue; unpatched 1.5.3 fails with Redis `NOAUTH`.
- [x] No unrelated changes bundled in

> Note on coverage: the **password-only** (`requirepass`) path is what was verified end-to-end on the real TrueNAS deployment. The **ACL user + password** path was verified against a live local Redis (preflight authenticates with the correct user/password and is rejected with the wrong one), but not against the real deployment.
