### PR TITLE
Default local DB/Redis host to 127.0.0.1 instead of localhost

### DIFF
--- a/immich_accelerator/__main__.py
+++ b/immich_accelerator/__main__.py
@@ -2523,12 +2523,16 @@ def _setup_local(args):
         "version": immich["version"],
         "server_dir": str(server_dir),
         "node": node,
-        "db_hostname": "localhost",
+        # Use 127.0.0.1, not "localhost": on macOS localhost resolves to
+        # ::1 (IPv6) first, but the Docker/OrbStack stack publishes these
+        # ports on 127.0.0.1 (IPv4) only, so "localhost" can hit ::1 and
+        # fail or stall. 127.0.0.1 connects directly to the published port.
+        "db_hostname": "127.0.0.1",
         "db_port": immich["db_port"],
         "db_username": immich["db_username"],
         "db_password": immich["db_password"],
         "db_name": immich["db_name"],
-        "redis_hostname": "localhost",
+        "redis_hostname": "127.0.0.1",
         "redis_port": immich["redis_port"],
         "upload_mount": upload,
         "ffmpeg_path": ffmpeg_path,


### PR DESCRIPTION
On macOS, localhost resolves to ::1 (IPv6) first, but the Docker/OrbStack stack publishes Postgres/Redis on 127.0.0.1 (IPv4) only, so localhost can hit ::1 and fail or stall.

127.0.0.1 connects straight to the published port. Only the auto-detected same-machine config is changed; remote/manual prompts are untouched.

[ This was surfaced while debugging an OrbStack 2.2.0 forward bug, but this is not actually related to that. This fix is to avoid the general macOS dual-stack pitfall. ]

## What this changes

`__main__.py`: Purely swaping "localhost" for "127.0.0.1" as the autodetected db/redis hostnames in the config file when generated.

Happy to submit another commit that removes the comments or trims (they're maybe a bit more tbh, but they won't end up in the actual config file).

## Checklist

- [✅] Ran `pytest -v -m "not slow"` locally — all tests pass
- [✅] Tested on a real Mac with the accelerator running
- [✅] No unrelated changes bundled in
