### PR TITLE
ci: bump actions to Node 24 versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Syntax check
@@ -36,10 +36,10 @@ jobs:
     # workflow bypasses CI entirely.
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -58,10 +58,10 @@ jobs:
     # Docker is pre-installed (macOS runners can't run Docker VMs).
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Generate compose from template
@@ -129,7 +129,7 @@ jobs:
       contents: write
       actions: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Check for version bump and tag

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -33,7 +33,7 @@ jobs:
           echo "sha256=$ML_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Checkout tap repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.repository_owner }}/homebrew-immich-accelerator
           token: ${{ secrets.TAP_TOKEN }}


### PR DESCRIPTION
GitHub [forces Node 24 for actions starting June 16, 2026](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/); `checkout@v4` and `setup-python@v5` run Node 20 and were already warning in CI logs.

- `actions/checkout` v4 → v6 (Node 24; v6 persists credentials to a separate file — `git push` in auto-tag is unaffected)
- `actions/setup-python` v5 → v6 (Node 24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)