### PR TITLE
Apply the #62 review fixes that missed the merge

### DIFF
--- a/immich_accelerator/__main__.py
+++ b/immich_accelerator/__main__.py
@@ -664,30 +664,36 @@ def detect_immich(docker: str) -> dict:
     except (json.JSONDecodeError, subprocess.SubprocessError):
         mounts = []
 
-    # Resolve the container's media location the way Immich itself does
+    # Find which mount holds the upload library the way Immich itself does
     # (services/storage.service.js detectMediaLocation): an explicit
     # IMMICH_MEDIA_LOCATION wins; otherwise Immich uses whichever of /data or
-    # /usr/src/app/upload exists in the container — for a bind mount that means
-    # it's a mount destination. The old detector hardcoded a "/upload"
-    # substring match, so it missed the modern default where uploads are
-    # mounted at /data (issue #62).
-    dests = {}
+    # /usr/src/app/upload exists in the container. The old detector hardcoded a
+    # "/upload" substring match, so it missed the modern default where uploads
+    # are bind-mounted at /data (issue #62).
+    #
+    # Only bind mounts qualify: the native worker reads files directly off disk,
+    # so a named/anonymous volume (Source lives inside Docker's VM) is no use.
+    bind_dests = {}
     for m in mounts:
+        if m.get("Type") and m.get("Type") != "bind":
+            continue
         d = m.get("Destination", "").rstrip("/")
-        if d:
-            dests.setdefault(d, m.get("Source", ""))
+        src = m.get("Source", "")
+        if d and src:
+            bind_dests.setdefault(d, src)
 
-    media_location = env.get("IMMICH_MEDIA_LOCATION", "").rstrip("/")
-    if not media_location or media_location not in dests:
+    media_env = env.get("IMMICH_MEDIA_LOCATION", "").rstrip("/")
+    media_dest = media_env if media_env in bind_dests else ""
+    if not media_dest:
         for candidate in ("/data", "/usr/src/app/upload"):
-            if candidate in dests:
-                media_location = media_location or candidate
+            if candidate in bind_dests:
+                media_dest = candidate
                 break
 
-    upload_mount = dests.get(media_location)
+    upload_mount = bind_dests.get(media_dest)
     if not upload_mount:
         # Last resort: legacy substring match for non-standard destinations.
-        for d, src in dests.items():
+        for d, src in bind_dests.items():
             if "/upload" in d:
                 upload_mount = src
                 break
@@ -707,7 +713,7 @@ def detect_immich(docker: str) -> dict:
         "upload_mount": upload_mount,
         "ml_url": env.get("IMMICH_MACHINE_LEARNING_URL", ""),
         "workers_include": env.get("IMMICH_WORKERS_INCLUDE", ""),
-        "media_location": media_location,
+        "media_location": env.get("IMMICH_MEDIA_LOCATION", ""),
     }
 
 

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -433,7 +433,9 @@ class TestDetectImmich:
         )
         info = self._detect_with("DB_PASSWORD=x\n", mounts)
         assert info["upload_mount"] == "/Volumes/4TB/Immich/Uploads"
-        assert info["media_location"] == "/data"
+        # media_location stays the raw env value (unset here) — see comment in
+        # detect_immich; the effective /data is used only to pick the mount.
+        assert info["media_location"] == ""
 
     def test_explicit_media_location_env_wins(self):
         """An explicit IMMICH_MEDIA_LOCATION picks the matching mount."""
@@ -454,7 +456,21 @@ class TestDetectImmich:
         )
         info = self._detect_with("", mounts)
         assert info["upload_mount"] == "/photos/upload"
-        assert info["media_location"] == "/usr/src/app/upload"
+
+    def test_named_volume_at_data_is_ignored(self):
+        """A non-bind mount at /data (Source inside Docker's VM) is not a usable
+        host path for the native worker, so it must not be chosen."""
+        mounts = json.dumps(
+            [
+                {
+                    "Type": "volume",
+                    "Destination": "/data",
+                    "Source": "/var/lib/docker/volumes/immich_data/_data",
+                }
+            ]
+        )
+        info = self._detect_with("", mounts)
+        assert info["upload_mount"] is None
 
     def test_no_media_mount_not_detected(self):
         """No /data or /upload mount → upload_mount stays None (not detected)."""


### PR DESCRIPTION
Follow-up to #63.

PR #63 unintentionally merged an **earlier draft** of the detection change — the reviewed version never made it in. (A chained `git commit --amend` was dropped when the accompanying force-push was hook-blocked, and the old commit got re-pushed.) Main currently has the draft, which has a real bug.

## What this fixes
- **Dead-state bug:** the merged draft returns the *effective* `media_location` (e.g. `/data`). Combined with the cmd_start media-location guard, that makes setup succeed but `start` always refuse with "WILL corrupt file paths" — and it suppresses the `_configure_docker` walkthrough that prints the alignment fix. This reverts `media_location` to the raw env value (detection still resolves the effective location internally to pick the mount).
- **Bind-mounts only:** a named/anonymous volume's `Source` lives inside Docker's VM and can't be read by the native worker, so only bind mounts are considered (plus a non-empty `Source` guard).

## Tests
Adds a named-volume-ignored test; keeps `/data`, explicit-env, legacy `/usr/src/app/upload`, and no-mount coverage. Full suite: 208 passed.

No version/CHANGELOG change — the 1.5.8 CHANGELOG entry from #63 already describes this corrected behavior. Please merge before tagging v1.5.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)