### PR TITLE
CI: weekly upstream-sync check + service-management docs

### DIFF
--- a/.github/workflows/upstream-sync-check.yml
+++ b/.github/workflows/upstream-sync-check.yml
@@ -1,0 +1,118 @@
+name: Upstream sync check
+
+# Notify (never auto-merge) when the bundled immich-ml-metal fork has drifted
+# behind upstream. ML changes alter inference behavior (CLIP backend, CoreML
+# providers) and must be validated live on Apple Silicon before shipping, so this
+# only opens/updates a tracking issue — the pull + validation stays a human step.
+#
+# Process when this fires (see the issue body):
+#   1. Branch `sync-upstream` off upstream main, cherry-pick our standing patches.
+#   2. Validate on a Mac (ml-test + a real OCR/face/CLIP round-trip).
+#   3. Merge to fork main, bump the `ml` submodule, release.
+#
+# Standing patches we always carry forward (must survive every sync):
+#   - mlx>=0.22.0,<0.31.2  (issue #38: CLIP threading crash on mlx 0.31.2)
+
+on:
+  schedule:
+    - cron: "0 14 * * 1" # Mondays 14:00 UTC
+  workflow_dispatch: {} # allow manual runs
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  UPSTREAM: sebastianfredette/immich-ml-metal
+  TRACKING_TITLE: "ML upstream sync: immich-ml-metal has new commits"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (with submodules)
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Compare our ml pin against upstream main
+        id: cmp
+        run: |
+          set -euo pipefail
+          cd ml
+          OUR_SHA="$(git rev-parse HEAD)"
+          git remote add upstream "https://github.com/${UPSTREAM}.git"
+          git fetch --quiet upstream main
+          UP_SHA="$(git rev-parse upstream/main)"
+
+          # Authoritative check: is upstream/main already contained in our pin?
+          # (Do NOT use the GitHub compare API across forks with a merge-commit
+          # base — it reports phantom "behind_by" counts. git is the source of
+          # truth here.)
+          if git merge-base --is-ancestor upstream/main HEAD; then
+            echo "behind=0" >> "$GITHUB_OUTPUT"
+            echo "✅ In sync. our=$OUR_SHA upstream=$UP_SHA"
+            exit 0
+          fi
+
+          COUNT="$(git rev-list --count HEAD..upstream/main)"
+          echo "behind=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "our_sha=$OUR_SHA" >> "$GITHUB_OUTPUT"
+          echo "up_sha=$UP_SHA" >> "$GITHUB_OUTPUT"
+
+          # Write the (untrusted) upstream commit messages to a FILE rather than
+          # GITHUB_OUTPUT: a crafted commit message containing the heredoc
+          # delimiter could otherwise break out and inject step outputs.
+          git log --oneline --no-decorate HEAD..upstream/main | head -50 \
+            > "$GITHUB_WORKSPACE/ml_behind.txt"
+
+          echo "⚠️  Behind by $COUNT commit(s)."
+
+      - name: Open or update tracking issue
+        if: steps.cmp.outputs.behind != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BEHIND: ${{ steps.cmp.outputs.behind }}
+          OUR_SHA: ${{ steps.cmp.outputs.our_sha }}
+          UP_SHA: ${{ steps.cmp.outputs.up_sha }}
+        run: |
+          set -euo pipefail
+          # Read untrusted upstream commit log from the file into a shell var.
+          # Bash does not re-evaluate the *value* of an expanded variable, so
+          # embedding "$LOG" in the heredoc below is not a command-injection
+          # vector (single-pass expansion).
+          LOG="$(cat "$GITHUB_WORKSPACE/ml_behind.txt")"
+
+          BODY="$(cat <<EOF
+          The bundled \`immich-ml-metal\` submodule is **$BEHIND commit(s) behind** upstream \`${UPSTREAM}\` main.
+
+          - our pin: \`$OUR_SHA\`
+          - upstream main: \`$UP_SHA\`
+
+          ### New upstream commits
+          \`\`\`
+          $LOG
+          \`\`\`
+
+          ### How to sync (human-validated; do not auto-merge)
+          1. In the \`ml\` fork: branch \`sync-upstream\` off upstream \`main\`, cherry-pick our standing patches.
+          2. **Validate on a Mac** — \`immich-accelerator ml-test\` plus a real OCR / face / CLIP round-trip.
+          3. Merge to fork \`main\`, bump the \`ml\` submodule here, cut a release.
+
+          Standing patches to carry forward every sync:
+          - \`mlx>=0.22.0,<0.31.2\` (#38 — CLIP threading crash)
+
+          _Opened automatically by the weekly upstream-sync check; updates in place until synced._
+          EOF
+          )"
+
+          EXISTING="$(gh issue list --state open --search "in:title \"$TRACKING_TITLE\"" --json number --jq '.[0].number // empty')"
+          if [ -n "$EXISTING" ]; then
+            gh issue edit "$EXISTING" --body "$BODY"
+            gh issue comment "$EXISTING" --body "Still behind by $BEHIND as of this run (upstream \`$UP_SHA\`)."
+            echo "Updated issue #$EXISTING"
+          else
+            gh issue create --title "$TRACKING_TITLE" --body "$BODY"
+            echo "Created tracking issue"
+          fi

--- a/README.md
+++ b/README.md
@@ -77,12 +77,12 @@ This is the directory Immich uses as its media root. It contains these subdirect
 | `immich-accelerator setup` | Auto-detect local Docker, extract server, configure |
 | `immich-accelerator setup --url URL` | Setup from remote Immich instance |
 | `immich-accelerator setup --manual` | Create config template for manual editing |
-| `immich-accelerator start` | Start native worker + ML |
+| `immich-accelerator start` | Start worker + ML once, foreground (testing; no auto-restart/update/log-rotation — see [Running as a service](#running-as-a-service-recommended)) |
 | `immich-accelerator stop` | Stop native services |
 | `immich-accelerator status` | Show what's running |
 | `immich-accelerator logs [worker\|ml]` | Tail service logs |
 | `immich-accelerator update` | Update to match new Immich version |
-| `immich-accelerator watch` | Monitor + auto-restart on crash (for launchd) |
+| `immich-accelerator watch` | Monitor + auto-restart/update + log rotation (what the service runs) |
 | `immich-accelerator dashboard` | Web UI at http://localhost:8420 |
 | `immich-accelerator ml-test` | Diagnose the ML service (health + CLIP + OCR round-trip) |
 | `immich-accelerator uninstall` | Remove services, data, and launchd config |
@@ -205,15 +205,29 @@ The ML service is a managed fork of [immich-ml-metal](https://github.com/sebasti
 
 Contributions to the ML service are made via [upstream PRs](https://github.com/sebastianfredette/immich-ml-metal/pulls).
 
-## Running as a service
+## Running as a service (recommended)
 
-Setup offers to install a launchd service automatically. If you skipped that prompt:
+Run the accelerator as a background service, not with a bare `immich-accelerator start`. The service runs `watch` mode, and **only `watch` mode gives you**:
+
+- **Auto-restart** — launchd (`KeepAlive`) restarts the monitor if it dies; the monitor restarts the worker, ML, and dashboard if they crash.
+- **Auto-update** — picks up new Immich versions (re-extracts the worker) and notifies on accelerator updates.
+- **Log rotation** — caps `worker.log`/`ml.log` so they can't grow without bound.
+
+A plain `immich-accelerator start` runs once in the foreground with none of the above — use it only for quick testing.
+
+**Homebrew install (recommended):**
 
 ```bash
-immich-accelerator setup  # re-run, it will offer again
+brew services start epheterson/immich-accelerator/immich-accelerator
 ```
 
-The service uses `watch` mode with `KeepAlive` — launchd restarts the monitor if it dies, and the monitor restarts worker, ML, and dashboard if they crash.
+This uses the formula's own service definition, survives `brew upgrade`, and restarts at login. Check it with `brew services list`. Stop with `brew services stop epheterson/immich-accelerator/immich-accelerator`.
+
+> Don't also install the launchd plist below if you're using `brew services` — running both double-starts the watcher.
+
+**Git / non-Homebrew install:** `immich-accelerator setup` offers to install a launchd LaunchAgent (`~/Library/LaunchAgents/com.immich.accelerator.plist`). If you skipped that prompt, re-run `setup` and it will offer again.
+
+Either way the service uses `watch` mode with `KeepAlive`. Confirm everything is healthy with `immich-accelerator status` and `immich-accelerator ml-test`.
 
 ## Safety
 


### PR DESCRIPTION
Adds a scheduled (weekly) GitHub Action that flags when the bundled `immich-ml-metal` submodule drifts behind upstream `sebastianfredette/immich-ml-metal` — the drift that left us ~2 months behind before the v1.5.13 sync.

## Behavior
- **Notify-only.** Opens (or updates in place) a single tracking issue listing the new upstream commits. Never auto-merges — ML changes alter inference behavior (CLIP backend, CoreML providers) and require live Apple-Silicon validation, so the pull stays a human step.
- Source of truth is `git merge-base --is-ancestor`, **not** the GitHub compare API (which reports phantom `behind_by` counts when the base is a fork merge-commit — confirmed this session).
- Runs Mondays 14:00 UTC; `workflow_dispatch` for manual runs.

## Security
Untrusted upstream commit messages are routed through a file + env vars (never interpolated into `run:` or `GITHUB_OUTPUT` heredocs), avoiding workflow-injection / output-injection.

## Notes
- Documents our standing patches that must survive every sync (currently `mlx<0.31.2`, #38).
- Immich-server compat isn't covered here: the worker auto-extracts from the running Docker image, so the only drift risk there is our shims — tracked separately if it becomes an issue.