### PR TITLE
fix(ci): upstream-sync mlx-pin job (GH_REPO + PyPI retry)

### DIFF
--- a/.github/workflows/upstream-sync-check.yml
+++ b/.github/workflows/upstream-sync-check.yml
@@ -136,11 +136,20 @@ jobs:
           # Python fetches PyPI itself (urllib) — don't pipe curl into `python3 -`
           # with a heredoc; the pipe and the heredoc both claim stdin.
           NEWER="$(PIN="$PIN" python3 <<'PY'
-          import json, os, urllib.request
+          import json, os, time, urllib.request
           from packaging.version import Version
           pin = Version(os.environ["PIN"])
-          with urllib.request.urlopen("https://pypi.org/pypi/mlx/json", timeout=30) as r:
-              data = json.load(r)
+          # PyPI occasionally resets the TLS handshake from CI runners; retry so a
+          # transient blip doesn't fail the weekly check.
+          for attempt in range(4):
+              try:
+                  with urllib.request.urlopen("https://pypi.org/pypi/mlx/json", timeout=30) as r:
+                      data = json.load(r)
+                  break
+              except Exception:
+                  if attempt == 3:
+                      raise
+                  time.sleep(5 * (attempt + 1))
           newer = []
           for ver, files in data["releases"].items():
               if not files or all(f.get("yanked") for f in files):
@@ -166,6 +175,7 @@ jobs:
         if: steps.mlx.outputs.newer != ''
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           NEWER: ${{ steps.mlx.outputs.newer }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## What
The weekly **Upstream sync check** failed today. Root cause: **mlx 0.32.0** shipped — the first version past the `<0.31.2` #38 CLIP pin — which fired the `mlx-pin` job's "Open or update pin re-test issue" step for the **first time ever**, exposing two latent bugs:

1. **`fatal: not a git repository`** — the `mlx-pin` job has no `actions/checkout`, so `gh issue` couldn't resolve the repo. Fixed by setting `GH_REPO` (gh reads it directly — no checkout needed).
2. **No retry on the PyPI fetch** — the scheduled run had also flaked earlier on a transient `Connection reset by peer` during the TLS handshake. Now retries up to 4× with backoff.

## Note
The signal itself is real and actionable: **mlx 0.32.0 is out**, so the #38 CLIP-crash pin is due for a re-test (the issue body the workflow will now open has the exact re-test procedure). This PR just makes the workflow surface that correctly instead of erroring.