### PR TITLE
native-ml: let onnxruntime use its own thread count instead of 1

### DIFF
--- a/native-ml/Sources/COnnxShim/include/ort_shim.h
+++ b/native-ml/Sources/COnnxShim/include/ort_shim.h
@@ -5,8 +5,8 @@
 // Minimal C wrapper over onnxruntime's C API, called from Swift. Keeps the
 // verbose OrtApi function-pointer dance in C where it reads naturally.
 
-// Load an ONNX model (CPU provider, single intra-op thread). Returns an opaque
-// handle, or NULL on failure.
+// Load an ONNX model (CPU provider, onnxruntime's default intra-op thread
+// count). Returns an opaque handle, or NULL on failure.
 void *ort_load(const char *model_path);
 
 // Run a single float tensor through the model. `shape`/`ndim` describe the input

--- a/native-ml/Sources/COnnxShim/ort_shim.c
+++ b/native-ml/Sources/COnnxShim/ort_shim.c
@@ -19,7 +19,15 @@ void *ort_load(const char *model_path) {
     if (!h) return NULL;
     if (g->CreateEnv(ORT_LOGGING_LEVEL_WARNING, "immich-ml", &h->env)) goto fail;
     g->CreateSessionOptions(&h->opts);
-    g->SetIntraOpNumThreads(h->opts, 1);
+    // 0 = onnxruntime picks its own default (hardware_concurrency-based).
+    // Was hardcoded to 1 since the engine's original ArcFace-only use case
+    // (a small face-embedding model, where single-threaded is plenty), but
+    // the v1.7.0 model zoo feature reuses this same session setup for CLIP
+    // models up to ~400M params, where single-threaded CPU is a real
+    // bottleneck (measured ~14x slower than the mlx default-model path on
+    // the same machine, and slower than the Python venv fallback's MPS
+    // path for the same model).
+    g->SetIntraOpNumThreads(h->opts, 0);
     g->SetSessionGraphOptimizationLevel(h->opts, ORT_ENABLE_ALL);
     if (g->CreateSession(h->env, model_path, h->opts, &h->session)) goto fail;
     OrtAllocator *alloc;


### PR DESCRIPTION
## What this changes

Thread count in onnxruntime was hardcoded to 1, fine for ArcFace but a bottleneck for the CLIP zoo's larger models. ~2.8x faster on SigLIP2 (535ms -> 160ms), identical output verified (cosine similarity 1.0).


## Checklist

- [x] Ran `pytest -v -m "not slow"` locally — all tests pass
- [x] Tested on a real Mac with the accelerator running
- [x] No unrelated changes bundled in
