### PR TITLE
Add --ml-only mode: run this Mac as a network-only ML compute node

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Every command is prefixed with `immich-accelerator` (e.g. `immich-accelerator se
 | `setup` | Auto-detect local Docker, extract server, configure |
 | `setup --url URL` | Set up from a remote Immich instance |
 | `setup --manual` | Create a config template for manual editing |
+| `setup --ml-only` | Set up this Mac as an [ML-only network compute node](#running-as-an-ml-only-network-node) |
 | `start` | Run worker + ML once in the foreground (testing only; use the [service](#running-as-a-service-recommended) for auto-restart/update/log-rotation) |
 | `stop` | Stop native services |
 | `status` | Show what's running |
@@ -218,6 +219,55 @@ The native engine is the default and is health-checked at startup. If its bundle
 Then restart the accelerator (`brew services restart epheterson/immich-accelerator/immich-accelerator`, or `immich-accelerator stop` then `start`). Set it back to `"native"` (or remove the key) and restart to return to native. Confirm which engine is live with `immich-accelerator ml-test` and check `ml.log`.
 
 The Python engine is a managed fork of [immich-ml-metal](https://github.com/sebastianfredette/immich-ml-metal) by [@sebastianfredette](https://github.com/sebastianfredette), included as a git submodule; upstream changes are reviewed before merging, and contributions are made via [upstream PRs](https://github.com/sebastianfredette/immich-ml-metal/pulls).
+
+## Running as an ML-only network node
+
+Dedicate a spare Apple Silicon Mac to ML compute only — no worker, no Docker, no
+Postgres, no Redis, no library mount — and point another Immich instance's stock
+**Administration → Machine Learning Settings → Remote Machine Learning URL** at it:
+
+```text
+http://<this-mac-ip>:3003
+```
+
+This turns the Mac into pure ML compute for an Immich instance (or several) running
+anywhere else on the network, without the shared-filesystem/path-alignment rules that
+[split deployment](#split-deployment-nas--mac-or-any-two-hosts) requires — because
+unlike the worker, the ML service never touches the library on disk, only the image
+bytes and text sent to it over HTTP.
+
+### Setup
+
+```bash
+immich-accelerator setup --ml-only
+```
+
+Finds (or offers to build) the Python venv fallback engine, writes a minimal config
+(`"ml_only": true`), and offers to start now and install as a launch-at-login service —
+same as a full install, minus every Docker/worker/database step.
+
+### What's different from a full install
+
+- `start` / `watch` / `brew services start` bring up only the ML engine (native Swift by
+  default, Python venv fallback) and the [dashboard](#dashboard) — no worker, no
+  `/build` link, no Immich version tracking, no database connectivity checks.
+- `status`, `stop`, `logs ml`, and `ml-test` all work exactly as in a full install.
+- The dashboard's processing-progress bars aren't meaningful here — there's no single
+  "owning" Immich library, since this node can serve any number of Immich instances —
+  so it shows ML health and Apple Silicon hardware utilization only.
+- Changing the CLIP/face model is still controlled entirely from each consuming
+  Immich instance's own admin settings, same as any other deployment — see
+  [ML service](#ml-service) above.
+
+### Security note
+
+The ML service binds `0.0.0.0:3003` (LAN-accessible) and, like Immich's own Docker ML
+service, has **no authentication** — anything that can reach the port can submit
+inference requests. This is the same trust model as Immich's stock `machine-learning`
+container; ml-only mode just makes it reachable from other hosts instead of only
+`localhost`. If you're on an untrusted network, put it behind a firewall or VPN and
+don't expose port 3003 to the internet — same guidance as the [dashboard's security
+note](#security) below.
 
 ## Running as a service (recommended)
 

--- a/immich_accelerator/__main__.py
+++ b/immich_accelerator/__main__.py
@@ -2519,8 +2519,11 @@ def _finalize_config(config: dict) -> None:
 
     save_config(config)
 
-    # Ensure /build firmlink for plugin path compatibility (Immich 2.7+)
-    _ensure_build_link()
+    # Ensure /build firmlink for plugin path compatibility (Immich 2.7+).
+    # Skip in ml-only mode: no worker, no Immich server files on this box —
+    # nothing needs /build to resolve.
+    if not config.get("ml_only"):
+        _ensure_build_link()
 
     # Auto-start services
     log.info("")
@@ -2567,7 +2570,12 @@ def _finalize_config(config: dict) -> None:
             subprocess.run(
                 ["launchctl", "load", str(plist_dst)], capture_output=True, timeout=10
             )
-            log.info("  Installed (auto-starts worker, ML, and dashboard on login)")
+            log.info(
+                "  Installed (auto-starts %s on login)",
+                "ML and dashboard"
+                if config.get("ml_only")
+                else "worker, ML, and dashboard",
+            )
 
     log.info("")
     log.info("Immich Accelerator is running.")
@@ -3681,9 +3689,46 @@ def _setup_manual(_args):
     log.info("  python -m immich_accelerator start")
 
 
+def _setup_ml_only(args) -> None:
+    """Set up this Mac as an ML-only network compute node: just the ML engine
+    (native Swift by default, Python venv fallback), reachable at this Mac's
+    IP on ml_port. No Docker, no Postgres, no Redis, no worker, no library
+    mount. Point another Immich instance's Administration -> Machine Learning
+    Settings -> Remote Machine Learning URL at this Mac.
+    """
+    log.info("Setting up ML-only mode (network ML compute node)...")
+    log.info("  This Mac will run only the ML engine — no worker, no Docker, no DB.")
+
+    ml_dir = _find_ml_dir()
+    if ml_dir:
+        log.info("  Python venv fallback: %s", ml_dir)
+    else:
+        log.warning(
+            "  Python ML source/venv not found — the venv fallback engine "
+            "won't be available."
+        )
+        log.warning(
+            "  The native Swift engine (if installed via Homebrew) still "
+            "works on its own."
+        )
+
+    config = {
+        "ml_only": True,
+        "ml_dir": str(ml_dir) if ml_dir else None,
+        "ml_port": 3003,
+    }
+    _finalize_config(config)
+
+    log.info("")
+    log.info("Point other Immich instances' Remote Machine Learning URL at:")
+    log.info("  http://<this-mac-ip>:%d", config["ml_port"])
+
+
 def cmd_setup(args):
-    """Set up the accelerator. Dispatches to local, remote, or manual mode."""
-    if args.manual:
+    """Set up the accelerator. Dispatches to local, remote, manual, or ml-only mode."""
+    if args.ml_only:
+        _setup_ml_only(args)
+    elif args.manual:
         _setup_manual(args)
     elif args.import_server and not args.url:
         # Standalone import: load existing config and import server files
@@ -4109,8 +4154,59 @@ def _kill_stale_processes():
         time.sleep(1)
 
 
+def _start_ml_only(config: dict, args) -> None:
+    """cmd_start's ml-only counterpart: bring up just the ML engine (and the
+    dashboard) as a network-reachable compute node. No Docker, no DB/Redis,
+    no worker, no /build link — none of that is relevant when this Mac's
+    only job is to answer /predict for some other Immich instance's "Remote
+    Machine Learning URL". Uses _start_ml_service (blocks on the health
+    check) rather than cmd_start's split preferred/verify dance: unlike the
+    worker path, there is no worker startup here to avoid delaying.
+    """
+    _kill_stale_processes()
+
+    ml_pid = read_pid("ml")
+    if ml_pid:
+        if not args.force:
+            log.info("Already running (PID %d). Use --force to restart.", ml_pid)
+            return
+        cmd_stop(None)
+
+    # Re-resolve ml_dir every start — config["ml_dir"] is a cache that goes
+    # stale when brew upgrade deletes the old Cellar directory (#29).
+    resolved_ml = _find_ml_dir()
+    if resolved_ml and str(resolved_ml) != config.get("ml_dir"):
+        log.info(
+            "ML path changed (%s -> %s) — updating config.",
+            config.get("ml_dir") or "(unset)",
+            resolved_ml,
+        )
+        config["ml_dir"] = str(resolved_ml)
+        save_config(config)
+
+    ml_pid, ml_engine = _start_ml_service(config)
+    if not ml_pid:
+        log.warning("ML service will not start (no native bundle, no venv).")
+        log.warning(
+            "  If you installed via Homebrew, try: brew reinstall immich-accelerator"
+        )
+        return
+    log.info("  ML service ready (PID %d, %s)", ml_pid, ml_engine)
+
+    # Bring up the dashboard too, so `start` is a complete bring-up.
+    start_dashboard()
+
+    log.info("")
+    log.info("Immich Accelerator running (ML-only)")
+    log.info("  ML log: %s/ml.log", LOG_DIR)
+
+
 def cmd_start(args):
     config = load_config()
+
+    if config.get("ml_only"):
+        _start_ml_only(config, args)
+        return
 
     # Kill any stale processes before starting
     _kill_stale_processes()
@@ -4632,11 +4728,71 @@ FD_RESTART_THRESHOLD = _int_env("IMMICH_ACCEL_FD_RESTART_THRESHOLD", 10000)
 FD_RESTART_COOLDOWN = _int_env("IMMICH_ACCEL_FD_RESTART_COOLDOWN", 300)
 
 
+def _watch_ml_only(config: dict) -> None:
+    """cmd_watch's ml-only counterpart: monitor and restart only the ML
+    service (and dashboard), forever. No fd-leak watchdog (that leak is
+    worker-only, #89) and no Docker/Immich-API polling (there is no local
+    server_dir to re-extract in ml-only mode).
+    """
+    log.info("Watching ML-only service (Ctrl+C to stop)...")
+
+    # `brew services stop`/`restart` send SIGTERM to this watcher, but ml/
+    # dashboard run detached (own session) and would survive — trap the
+    # signal and stop them before exiting, matching cmd_watch's behavior.
+    def _graceful_stop(signum, _frame):
+        log.info("Received signal %d, stopping services...", signum)
+        try:
+            stop_all_fast()
+        finally:
+            sys.exit(0)
+
+    signal.signal(signal.SIGTERM, _graceful_stop)
+    signal.signal(signal.SIGINT, _graceful_stop)
+
+    if not read_pid("ml"):
+        log.info("Service not running, starting...")
+        _start_ml_only(config, argparse.Namespace(force=True))
+    else:
+        reconcile_dashboard()
+
+    while True:
+        try:
+            time.sleep(30)
+            config = load_config()  # reload each cycle (setup may have changed it)
+
+            # Keep service logs bounded, same as the worker path.
+            cap_service_logs()
+
+            reconcile_dashboard()
+
+            # Check ML — re-resolve ml_dir each cycle (brew upgrade can
+            # invalidate it), same as cmd_watch's worker-path check.
+            if not read_pid("ml"):
+                log.warning("ML service not running — attempting restart...")
+                resolved_ml = _find_ml_dir()
+                if resolved_ml and str(resolved_ml) != config.get("ml_dir"):
+                    config["ml_dir"] = str(resolved_ml)
+                    save_config(config)
+                pid, engine = _start_ml_service(config)
+                if pid:
+                    log.info("  ML restarted (PID %d, %s)", pid, engine)
+                else:
+                    log.error("  ML restart failed")
+        except KeyboardInterrupt:
+            log.info("Watch stopped")
+            return
+
+
 def cmd_watch(_args):
     """Monitor services and restart on crash. Detects Docker updates.
 
     Suitable for launchd KeepAlive — runs forever, checking every 30s.
     """
+    config = load_config()
+    if config.get("ml_only"):
+        _watch_ml_only(config)
+        return
+
     log.info("Watching services (Ctrl+C to stop)...")
 
     if FD_RESTART_THRESHOLD > 0 and _LIBPROC is None:
@@ -5230,6 +5386,11 @@ def main():
         "--import-server",
         metavar="DIR",
         help="Import server from extracted directory or tarball",
+    )
+    setup_p.add_argument(
+        "--ml-only",
+        action="store_true",
+        help="Set up this Mac as an ML-only network compute node (no worker, no DB)",
     )
     start_p = sub.add_parser("start", help="Start native worker + ML")
     start_p.add_argument("--force", action="store_true", help="Restart if running")

--- a/immich_accelerator/dashboard.py
+++ b/immich_accelerator/dashboard.py
@@ -187,7 +187,13 @@ def get_status(config: dict) -> dict:
     # deleted/hidden assets — that's how completion read >100% (#68).
     #   live = asset, deletedAt IS NULL, visibility != hidden
     #   awp  = live + has an asset_job_status row + has a Preview file
-    counts_raw = _query_db(
+    #
+    # Skipped entirely in ml-only mode: there's no local Postgres to query
+    # (by design — this box has no worker, no library, no DB), so every
+    # uncached poll would otherwise spawn a doomed psql/docker-exec call and
+    # log a misleading "cannot connect to Postgres" line. Progress bars stay
+    # at 0/0, which is accurate — this node isn't "the" library.
+    counts_raw = "" if config.get("ml_only") else _query_db(
         "WITH live AS ("
         "  SELECT id, type, thumbhash FROM asset"
         "  WHERE \"deletedAt\" IS NULL AND visibility != 'hidden'), "

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -650,6 +650,16 @@ class TestCLIParsing:
         args = parser.parse_args(["setup", "--import-server", "/tmp/server.tar.gz"])
         assert args.import_server == "/tmp/server.tar.gz"
 
+    def test_setup_ml_only_flag(self):
+        parser = self._build_parser()
+        args = parser.parse_args(["setup", "--ml-only"])
+        assert args.ml_only is True
+
+    def test_setup_ml_only_defaults_false(self):
+        parser = self._build_parser()
+        args = parser.parse_args(["setup"])
+        assert args.ml_only is False
+
     def test_start_command(self):
         parser = self._build_parser()
         args = parser.parse_args(["start"])
@@ -730,6 +740,7 @@ class TestCLIParsing:
         setup_p.add_argument("--api-key")
         setup_p.add_argument("--manual", action="store_true")
         setup_p.add_argument("--import-server", metavar="DIR")
+        setup_p.add_argument("--ml-only", action="store_true")
         start_p = sub.add_parser("start")
         start_p.add_argument("--force", action="store_true")
         sub.add_parser("stop")
@@ -975,6 +986,240 @@ class TestStartMlService:
             pid, engine = m._start_ml_service(cfg)
             assert engine == "Python venv"
             nat.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# ml-only mode: cmd_start/cmd_watch dispatch to a worker-free counterpart
+# ---------------------------------------------------------------------------
+
+
+class TestStartMlOnly:
+    """_start_ml_only, and cmd_start's dispatch to it."""
+
+    CFG = {"ml_only": True, "ml_dir": "/ml", "ml_port": 3003}
+
+    def test_cmd_start_dispatches_to_ml_only_and_skips_worker_path(self, tmp_data_dir):
+        import immich_accelerator.__main__ as m
+
+        with patch.object(
+            m, "load_config", return_value=dict(self.CFG)
+        ), patch.object(m, "_start_ml_only") as start_ml_only, patch.object(
+            m, "find_docker"
+        ) as find_docker, patch.object(
+            m, "_preflight_env_health"
+        ) as preflight, patch.object(
+            m, "ensure_media_ready"
+        ) as media_ready:
+            m.cmd_start(argparse.Namespace(force=False))
+            start_ml_only.assert_called_once()
+            find_docker.assert_not_called()
+            preflight.assert_not_called()
+            media_ready.assert_not_called()
+
+    def test_already_running_without_force_skips_start(self, tmp_data_dir):
+        import immich_accelerator.__main__ as m
+
+        with patch.object(m, "_kill_stale_processes"), patch.object(
+            m, "read_pid", return_value=1234
+        ), patch.object(m, "cmd_stop") as stop, patch.object(
+            m, "_start_ml_service"
+        ) as start_ml:
+            m._start_ml_only(dict(self.CFG), argparse.Namespace(force=False))
+            start_ml.assert_not_called()
+            stop.assert_not_called()
+
+    def test_force_stops_then_restarts(self, tmp_data_dir):
+        import immich_accelerator.__main__ as m
+
+        with patch.object(m, "_kill_stale_processes"), patch.object(
+            m, "read_pid", return_value=1234
+        ), patch.object(m, "cmd_stop") as stop, patch.object(
+            m, "_find_ml_dir", return_value=None
+        ), patch.object(
+            m, "_start_ml_service", return_value=(999, "native Swift")
+        ), patch.object(
+            m, "start_dashboard"
+        ) as start_dash:
+            m._start_ml_only(dict(self.CFG), argparse.Namespace(force=True))
+            stop.assert_called_once_with(None)
+            start_dash.assert_called_once()
+
+    def test_starts_dashboard_on_success(self, tmp_data_dir):
+        import immich_accelerator.__main__ as m
+
+        with patch.object(m, "_kill_stale_processes"), patch.object(
+            m, "read_pid", return_value=None
+        ), patch.object(m, "_find_ml_dir", return_value=None), patch.object(
+            m, "_start_ml_service", return_value=(111, "Python venv")
+        ), patch.object(
+            m, "start_dashboard"
+        ) as start_dash:
+            m._start_ml_only(dict(self.CFG), argparse.Namespace(force=False))
+            start_dash.assert_called_once()
+
+    def test_no_engine_available_does_not_start_dashboard(self, tmp_data_dir):
+        import immich_accelerator.__main__ as m
+
+        with patch.object(m, "_kill_stale_processes"), patch.object(
+            m, "read_pid", return_value=None
+        ), patch.object(m, "_find_ml_dir", return_value=None), patch.object(
+            m, "_start_ml_service", return_value=(None, None)
+        ), patch.object(
+            m, "start_dashboard"
+        ) as start_dash:
+            m._start_ml_only(dict(self.CFG), argparse.Namespace(force=False))
+            start_dash.assert_not_called()
+
+
+class TestWatchMlOnly:
+    """_watch_ml_only, and cmd_watch's dispatch to it."""
+
+    CFG = {"ml_only": True, "ml_dir": "/ml", "ml_port": 3003}
+
+    def test_cmd_watch_dispatches_to_ml_only_and_skips_worker_path(self, tmp_data_dir):
+        import immich_accelerator.__main__ as m
+
+        with patch.object(
+            m, "load_config", return_value=dict(self.CFG)
+        ), patch.object(m, "_watch_ml_only") as watch_ml_only, patch.object(
+            m, "cmd_start"
+        ) as cmd_start:
+            m.cmd_watch(argparse.Namespace())
+            watch_ml_only.assert_called_once()
+            cmd_start.assert_not_called()
+
+    def test_skips_worker_only_checks_in_loop(self, tmp_data_dir):
+        """Regression guard: the ml-only loop must never touch the worker
+        crash-restart path, the fd-leak watchdog, or Docker version polling."""
+        import immich_accelerator.__main__ as m
+
+        with patch.object(m, "read_pid", return_value=4321), patch.object(
+            m, "reconcile_dashboard"
+        ), patch.object(m, "load_config", return_value=dict(self.CFG)), patch.object(
+            m, "cap_service_logs"
+        ), patch.object(
+            m, "cmd_start"
+        ) as cmd_start, patch.object(
+            m, "_worker_fd_total"
+        ) as fd_total, patch.object(
+            m, "find_docker"
+        ) as find_docker, patch(
+            "signal.signal"
+        ), patch(
+            "time.sleep", side_effect=KeyboardInterrupt
+        ):
+            m._watch_ml_only(dict(self.CFG))
+            cmd_start.assert_not_called()
+            fd_total.assert_not_called()
+            find_docker.assert_not_called()
+
+    def test_starts_when_not_already_running(self, tmp_data_dir):
+        import immich_accelerator.__main__ as m
+
+        with patch.object(m, "read_pid", return_value=None), patch.object(
+            m, "reconcile_dashboard"
+        ), patch.object(m, "_start_ml_only") as start_ml_only, patch(
+            "signal.signal"
+        ), patch(
+            "time.sleep", side_effect=KeyboardInterrupt
+        ):
+            m._watch_ml_only(dict(self.CFG))
+            start_ml_only.assert_called_once()
+
+    def test_restarts_ml_on_crash_inside_loop(self, tmp_data_dir):
+        import immich_accelerator.__main__ as m
+
+        # First read_pid call is the pre-loop check (live -> no initial start).
+        # Second is inside the loop body (crashed -> triggers a restart).
+        with patch.object(
+            m, "read_pid", side_effect=[4321, None]
+        ), patch.object(m, "reconcile_dashboard"), patch.object(
+            m, "load_config", return_value=dict(self.CFG)
+        ), patch.object(
+            m, "cap_service_logs"
+        ), patch.object(
+            m, "_find_ml_dir", return_value=None
+        ), patch.object(
+            m, "_start_ml_service", return_value=(555, "native Swift")
+        ) as start_ml, patch.object(
+            m, "_start_ml_only"
+        ) as start_ml_only, patch(
+            "signal.signal"
+        ), patch(
+            "time.sleep", side_effect=[None, KeyboardInterrupt]
+        ):
+            m._watch_ml_only(dict(self.CFG))
+            start_ml_only.assert_not_called()  # already running at the pre-loop check
+            start_ml.assert_called_once()  # in-loop restart after it "crashed"
+
+
+class TestSetupMlOnly:
+    """_setup_ml_only, cmd_setup's dispatch to it, and the shared
+    _finalize_config's ml-only guard around _ensure_build_link()."""
+
+    def test_cmd_setup_ml_only_dispatches(self):
+        import immich_accelerator.__main__ as m
+
+        args = argparse.Namespace(
+            ml_only=True, manual=False, import_server=None, url=None
+        )
+        with patch.object(m, "_setup_ml_only") as setup_ml_only, patch.object(
+            m, "_setup_local"
+        ) as setup_local, patch.object(
+            m, "_setup_manual"
+        ) as setup_manual, patch.object(
+            m, "_setup_remote"
+        ) as setup_remote:
+            m.cmd_setup(args)
+            setup_ml_only.assert_called_once_with(args)
+            setup_local.assert_not_called()
+            setup_manual.assert_not_called()
+            setup_remote.assert_not_called()
+
+    def test_writes_minimal_config_with_no_worker_fields(self, tmp_data_dir):
+        import immich_accelerator.__main__ as m
+
+        with patch.object(
+            m, "_find_ml_dir", return_value=Path("/ml")
+        ), patch.object(m, "_finalize_config") as finalize:
+            m._setup_ml_only(argparse.Namespace())
+            finalize.assert_called_once()
+            written = finalize.call_args[0][0]
+            assert written["ml_only"] is True
+            assert written["ml_port"] == 3003
+            assert written["ml_dir"] == "/ml"
+            for worker_key in ("db_hostname", "server_dir", "upload_mount"):
+                assert worker_key not in written
+
+    def test_handles_missing_venv(self, tmp_data_dir):
+        import immich_accelerator.__main__ as m
+
+        with patch.object(m, "_find_ml_dir", return_value=None), patch.object(
+            m, "_finalize_config"
+        ) as finalize:
+            m._setup_ml_only(argparse.Namespace())
+            written = finalize.call_args[0][0]
+            assert written["ml_dir"] is None
+
+    def test_finalize_config_skips_build_link_when_ml_only(self, tmp_data_dir):
+        import immich_accelerator.__main__ as m
+
+        with patch.object(m, "_ensure_build_link") as build_link, patch(
+            "builtins.input", side_effect=EOFError
+        ), patch("subprocess.run"):
+            m._finalize_config({"ml_only": True})
+            build_link.assert_not_called()
+
+    def test_finalize_config_still_calls_build_link_when_not_ml_only(
+        self, tmp_data_dir, sample_config
+    ):
+        import immich_accelerator.__main__ as m
+
+        with patch.object(m, "_ensure_build_link") as build_link, patch(
+            "builtins.input", side_effect=EOFError
+        ), patch("subprocess.run"):
+            m._finalize_config(dict(sample_config))
+            build_link.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this changes

No worker, no Docker, no DB — just the ML engine, reachable for other Immich instances' Remote Machine Learning URL. cmd_start/cmd_watch dispatch to worker-free counterparts via a single guard; existing paths are untouched. 18 new tests; full suite still passes.

## Checklist

- [x] Ran `pytest -v -m "not slow"` locally — all tests pass
- [x] Tested on a real Mac with the accelerator running
- [x] No unrelated changes bundled in
