### PR TITLE
fix: stream ml logs in real time for both native and python engines

### DIFF
--- a/immich_accelerator/__main__.py
+++ b/immich_accelerator/__main__.py
@@ -3978,6 +3978,11 @@ def _venv_ml_spec(config: dict, env: dict):
     ml_dir = Path(config.get("ml_dir", ""))
     ml_python = ml_dir / "venv" / "bin" / "python3"
     if ml_python.exists():
+        # stdout is block-buffered once it's not a tty (always true — we redirect
+        # it into ml.log), which is where uvicorn's access log and any print()
+        # output live. Without this, `logs ml` sits blank and then dumps a stale
+        # chunk instead of streaming in real time.
+        env = dict(env, PYTHONUNBUFFERED="1")
         return [str(ml_python), "-m", "src.main"], str(ml_dir), env
     return None
 

--- a/native-ml/Sources/immich-ml-native/Predict.swift
+++ b/native-ml/Sources/immich-ml-native/Predict.swift
@@ -2,8 +2,10 @@ import Foundation
 import CoreGraphics
 
 // Dispatch a /predict request across requested tasks and assemble Immich's
-// response dict. Mirrors ml/src/main.py _process_predict: clip (visual|textual),
-// facial-recognition, ocr; omits fields that weren't requested.
+// response dict. Mirrors ml/src/main.py's _process_predict both in behavior
+// and in its [native-ml]-prefixed log output: same "  <task>: Nms" per-task
+// lines and "predict: N task(s) [...] completed in Nms" summary, so `logs ml`
+// reads the same regardless of which engine is running.
 struct PredictError: Error { let status: String; let message: String }
 
 func processPredict(entries: [String: Any], imageData: Data?, text: String?, models: Models) throws -> [String: Any] {
@@ -17,6 +19,7 @@ func processPredict(entries: [String: Any], imageData: Data?, text: String?, mod
     var W = 0, H = 0
     if let data = imageData {
         guard let img = loadCGImage(data: data) else {
+            print("[native-ml] Failed to read/decode image")
             throw PredictError(status: "400 Bad Request", message: "Invalid image")
         }
         cg = img
@@ -26,28 +29,48 @@ func processPredict(entries: [String: Any], imageData: Data?, text: String?, mod
         response["imageHeight"] = H
     }
 
-    for (taskType, cfgAny) in entries {
+    // Requested task types, in a fixed order — mirrors python's
+    // `[t for t in tasks.keys() if t in (...)]` used for the summary line.
+    // Reflects what was requested, not what actually produced a result (same
+    // as python: a task that silently no-ops still counts here).
+    let requestedTaskNames = ["clip", "facial-recognition", "ocr"].filter { entries[$0] != nil }
+
+    // Prints "  <name>: Nms" once `body` returns true (a result was produced),
+    // matching python's `_timed` wrapper, which only logs `if result is not None`.
+    func timed(_ name: String, _ body: () throws -> Bool) rethrows {
+        let t0 = DispatchTime.now()
+        let ran = try body()
+        guard ran else { return }
+        let ms = Double(DispatchTime.now().uptimeNanoseconds - t0.uptimeNanoseconds) / 1_000_000
+        print("[native-ml]   \(name): \(String(format: "%.0f", ms))ms")
+    }
+
+    let overallStart = DispatchTime.now()
+
+    if let cfgAny = entries["clip"] {
         let cfg = cfgAny as? [String: Any] ?? [:]
-        switch taskType {
-        case "clip":
+        try timed("clip") {
             if let vCfg = cfg["visual"] as? [String: Any], let cg = cg {
                 let name = Models.normalize(vCfg["modelName"] as? String ?? Models.defaultClip)
-                if name == Models.defaultClip {
-                    response["clip"] = pyListString(models.clipVisual.embed(cg))
-                } else {
-                    response["clip"] = pyListString(try models.zoo(for: name).embedVisual(cg))
-                }
+                response["clip"] = name == Models.defaultClip
+                    ? pyListString(models.clipVisual.embed(cg))
+                    : pyListString(try models.zoo(for: name).embedVisual(cg))
+                return true
             } else if let tCfg = cfg["textual"] as? [String: Any], let t = text {
                 let name = Models.normalize(tCfg["modelName"] as? String ?? Models.defaultClip)
-                if name == Models.defaultClip {
-                    response["clip"] = pyListString(models.clipText.encode(t))
-                } else {
-                    response["clip"] = pyListString(try models.zoo(for: name).embedTextual(t))
-                }
+                response["clip"] = name == Models.defaultClip
+                    ? pyListString(models.clipText.encode(t))
+                    : pyListString(try models.zoo(for: name).embedTextual(t))
+                return true
             }
+            return false
+        }
+    }
 
-        case "facial-recognition":
-            guard let data = imageData, let rgb = rgb, let ort = models.arcface else { break }
+    if let cfgAny = entries["facial-recognition"] {
+        let cfg = cfgAny as? [String: Any] ?? [:]
+        timed("faces") {
+            guard let data = imageData, let rgb = rgb, let ort = models.arcface else { return false }
             let minScore = optDouble(cfg, "detection", "minScore") ?? 0.7
             let faces = detectFacesWithLandmarks(imageData: data, width: W, height: H)
                 .filter { Double($0.score) >= minScore }
@@ -61,19 +84,28 @@ func processPredict(entries: [String: Any], imageData: Data?, text: String?, mod
                     "score": Double(f.score),
                 ])
             }
+            print("[native-ml]   faces: \(out.count) detected")
             response["facial-recognition"] = out
+            return true
+        }
+    }
 
-        case "ocr":
-            guard let data = imageData else { break }
+    if let cfgAny = entries["ocr"] {
+        let cfg = cfgAny as? [String: Any] ?? [:]
+        timed("ocr") {
+            guard let data = imageData else { return false }
             let det = optDouble(cfg, "detection", "minScore") ?? 0.0
             let rec = optDouble(cfg, "recognition", "minScore") ?? 0.0
             response["ocr"] = recognizeTextImmich(imageData: data, minScore: Float(max(det, rec)),
                                                   languageCorrection: true)
-
-        default:
-            break
+            return true
         }
     }
+
+    let totalMs = Double(DispatchTime.now().uptimeNanoseconds - overallStart.uptimeNanoseconds) / 1_000_000
+    print("[native-ml] predict: \(requestedTaskNames.count) task(s) "
+        + "[\(requestedTaskNames.joined(separator: "+"))] completed in \(String(format: "%.0f", totalMs))ms")
+
     return response
 }
 

--- a/native-ml/Sources/immich-ml-native/Server.swift
+++ b/native-ml/Sources/immich-ml-native/Server.swift
@@ -83,14 +83,24 @@ private func handle(_ conn: NWConnection, method: String, path: String, ctype: S
         }
         respondJSON(conn, status: "200 OK", object: health)
     case "/predict":
+        // Mirrors ml/src/main.py's request-logging middleware + _process_predict
+        // line-for-line (see Predict.swift for the rest): same message content,
+        // just prefixed with [native-ml] instead of the python logger's
+        // "TIMESTAMP - src.main - INFO -" preamble. Skips /ping and /health,
+        // which are polled every few seconds and would just be noise.
+        print("[native-ml] \(method) /predict")
         guard let boundary = ctype.range(of: "boundary=").map({
             String(ctype[$0.upperBound...]).trimmingCharacters(in: .whitespaces)
         }) else {
             respondJSON(conn, status: "400 Bad Request", object: ["detail": "expected multipart/form-data"]); return
         }
         guard let entriesData = extractPart(body, boundary: boundary, name: "entries"),
-              let entriesStr = String(data: entriesData, encoding: .utf8),
-              let entries = (try? JSONSerialization.jsonObject(with: Data(entriesStr.utf8))) as? [String: Any] else {
+              let entriesStr = String(data: entriesData, encoding: .utf8) else {
+            respondJSON(conn, status: "422 Unprocessable Entity", object: ["detail": "missing entries field"]); return
+        }
+        print("[native-ml] entries raw: \(entriesStr)")
+        guard let entries = (try? JSONSerialization.jsonObject(with: Data(entriesStr.utf8))) as? [String: Any] else {
+            print("[native-ml] Invalid entries JSON")
             respondJSON(conn, status: "422 Unprocessable Entity", object: ["detail": "invalid entries JSON"]); return
         }
         let image = extractPart(body, boundary: boundary, name: "image")

--- a/native-ml/Sources/immich-ml-native/main.swift
+++ b/native-ml/Sources/immich-ml-native/main.swift
@@ -1,6 +1,12 @@
 import Foundation
 import MLX
 
+// stdout is fully block-buffered by libc once it isn't a tty (always true here —
+// launchd/immich-accelerator redirect it to a log file), so `immich-accelerator
+// logs ml` would sit blank for a while and then dump a stale chunk. Line-buffer
+// it so every print() shows up in the log as soon as it happens.
+setvbuf(stdout, nil, _IOLBF, 0)
+
 // Native Swift ML service prototype: CLIP (mlx-swift) + OCR + face-detect (Vision).
 // Proves the whole ML compute layer can be native — no Python, no venv, no torch.
 


### PR DESCRIPTION
## What this changes

- `logs ml` sat blank/stale while the ML service was actively processing, under both the native and python engines — root cause was stdout being fully block-buffered once it's redirected to a log file (not a tty).
- The native engine also logged nothing per request at all, unlike the python engine which gets an access log for free from uvicorn.

## Changes

- native-ml: `setvbuf(stdout, nil, _IOLBF, 0)` at startup forces line buffering; added a `[native-ml] METHOD /predict -> status (Nms)` log line per request (excludes /ping and /health, which are polled every few seconds and would just be noise).
- immich_accelerator: `PYTHONUNBUFFERED=1` for the venv engine's env.

## Checklist

- [x] Ran `pytest -v -m "not slow"` locally — all tests pass
- [x] Tested on a real Mac with the accelerator running
- [x] No unrelated changes bundled in
