### PR TITLE
Fix HEIC/RAW decode blocking the event loop and starving BullMQ lock renewal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **HEIC/RAW thumbnails could fail permanently on a NAS-backed library.** The decode shim blocked the worker's event loop (and BullMQ's lock-renewal timer) for the whole decode, and a previous fix shrank the timeout to work around that — which broke any decode slower than a few seconds, common when the library lives on a NAS over SMB. The decoder now runs async, so a slow decode no longer blocks anything, and decode concurrency is capped at 1 by default (`IMMICH_ACCELERATOR_HEIC_DECODE_CONCURRENCY` to raise it) since this NAS measurably slows down under concurrent reads.
+
 ## 1.9.0 - 2026-08-07
 
 ### Added

--- a/immich_accelerator/hooks/heic_decode_shim.js
+++ b/immich_accelerator/hooks/heic_decode_shim.js
@@ -50,6 +50,9 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const cp = require('child_process');
+const util = require('util');
+
+const execFileAsync = util.promisify(cp.execFile);
 
 // Resolve a decoder binary. An explicit env override is honored VERBATIM: an
 // operator forcing a specific build should fail loudly (a bad path errors on
@@ -184,10 +187,11 @@ function isRawPath(input) {
     return RAW_EXTS.has(input.slice(dot + 1).toLowerCase());
 }
 
-// The decode runs synchronously in the sharp() constructor, so a hung decoder
-// stalls the worker's event loop. Cap the TOTAL time across all decoders (not
-// per-decoder) so trying the fallback can't multiply the worst case.
-const DECODE_BUDGET_MS = 30000;
+// Decode now runs via async execFile, so a slow decode can't block the event
+// loop or starve BullMQ's lock renewal — this is a hang-safety ceiling, not
+// an event-loop-protection lever. Raised well above 8s because a NAS-backed
+// library (e.g. SMB) can take 20+ seconds for a normal read, not a hang.
+const DECODE_BUDGET_MS = Number(process.env.IMMICH_ACCELERATOR_HEIC_DECODE_BUDGET_MS) || 120000;
 
 // A real TIFF starts with "II*\0" (little-endian) or "MM\0*" (big-endian). Both
 // our decoders emit TIFF; requiring the magic rejects an empty or half-written
@@ -221,11 +225,43 @@ function decoderEnv() {
     return process.env;
 }
 
-// Decode a HEIC file to a lossless TIFF buffer, trying each available decoder in
-// preference order until one yields a valid TIFF. Returns the buffer, or null if
-// every decoder is unavailable or fails (caller falls back to the real Sharp, so
-// behavior is never worse than without the shim).
-function decodeToBuffer(input) {
+// Async execFile lets BullMQ run several decodes concurrently, but a modest
+// NAS degrades under concurrent reads instead of parallelizing them —
+// measured, 4 concurrent vips decodes took 37s+ (still not done) vs 20.7s for
+// one alone. Cap concurrent decoder processes; default 1 matches what
+// execFileSync gave for free before.
+const DECODE_CONCURRENCY = Number(process.env.IMMICH_ACCELERATOR_HEIC_DECODE_CONCURRENCY) || 1;
+let activeDecodes = 0;
+const decodeWaitQueue = [];
+function acquireDecodeSlot() {
+    if (activeDecodes < DECODE_CONCURRENCY) {
+        activeDecodes += 1;
+        return Promise.resolve();
+    }
+    return new Promise((resolve) => decodeWaitQueue.push(resolve));
+}
+function releaseDecodeSlot() {
+    const next = decodeWaitQueue.shift();
+    if (next) {
+        next();
+    } else {
+        activeDecodes -= 1;
+    }
+}
+
+// Decode a HEIC file to a lossless TIFF buffer, trying each decoder in
+// preference order until one yields a valid TIFF. Resolves to null if none
+// succeed (caller falls back to real Sharp).
+async function decodeToBuffer(input) {
+    await acquireDecodeSlot();
+    try {
+        return await decodeToBufferUnthrottled(input);
+    } finally {
+        releaseDecodeSlot();
+    }
+}
+
+async function decodeToBufferUnthrottled(input) {
     const deadline = Date.now() + DECODE_BUDGET_MS;
     let attempted = 0;
     for (const dec of DECODERS) {
@@ -238,8 +274,7 @@ function decodeToBuffer(input) {
             `iaa-heic-${process.pid}-${Date.now()}-${Math.floor(Math.random() * 1e9)}.tiff`
         );
         try {
-            cp.execFileSync(dec.bin, dec.args(input, tmp), {
-                stdio: ['ignore', 'ignore', 'pipe'],
+            await execFileAsync(dec.bin, dec.args(input, tmp), {
                 timeout: remaining,
                 env: decoderEnv(),
             });
@@ -267,18 +302,50 @@ function decodeToBuffer(input) {
     return null;
 }
 
+// then/catch/finally must not look like chain methods, or code that
+// duck-types "is this a Promise" would misbehave.
+const NON_CHAIN_PROPS = new Set(['then', 'catch', 'finally', 'constructor']);
+
+// These trigger real pixel decode and return a Promise; everything else
+// Immich calls (rotate, resize, toFormat, ...) is a synchronous setter.
+const TERMINAL_ASYNC_METHODS = new Set(['toBuffer', 'toFile', 'metadata', 'stats']);
+
+// sharp() must return synchronously and support chaining even though decode
+// is now async. Records synchronous chain calls and replays them once decode
+// resolves; a terminal call (toBuffer etc.) awaits it first.
+function lazyDecodedSharp(input, options, realSharp) {
+    const ready = decodeToBuffer(input).then(
+        (buf) => realSharp(buf !== null ? buf : input, options)
+    );
+    const calls = [];
+    const proxy = new Proxy(function () {}, {
+        get(_target, prop) {
+            if (typeof prop === 'symbol' || NON_CHAIN_PROPS.has(prop)) return undefined;
+            if (TERMINAL_ASYNC_METHODS.has(prop)) {
+                return async (...args) => {
+                    let instance = await ready;
+                    for (const [method, methodArgs] of calls) {
+                        instance = instance[method](...methodArgs);
+                    }
+                    return instance[prop](...args);
+                };
+            }
+            return (...args) => {
+                calls.push([prop, args]);
+                return proxy;
+            };
+        },
+    });
+    return proxy;
+}
+
 // Wrap the real Sharp factory so HEVC-HEIC paths are pre-decoded.
 function wrapSharp(realSharp) {
     function sharp(input, options) {
         // isRawPath is a pure string check; isHevcHeicPath reads the ftyp box.
         // Test the cheap one first so RAW paths route with no filesystem I/O.
         if (isRawPath(input) || isHevcHeicPath(input)) {
-            const buf = decodeToBuffer(input);
-            if (buf !== null) {
-                return realSharp(buf, options);
-            }
-            // Fall through to the real Sharp so the user still gets Immich's
-            // normal (libheif) error path rather than a silent difference.
+            return lazyDecodedSharp(input, options, realSharp);
         }
         return realSharp(input, options);
     }

--- a/tests/test_fresh_install.py
+++ b/tests/test_fresh_install.py
@@ -1434,7 +1434,11 @@ class TestHeicDecodeShim:
             "function fakeSharp(input){"
             "process.stdout.write('INPUT_TYPE:'+"
             "(Buffer.isBuffer(input)?'buffer':typeof input)+'\\n');"
-            "return {};}"
+            # A real Sharp instance is only usable via its (async) output
+            # methods; the shim's lazy proxy defers the decode until one of
+            # those is called. metadata() here stands in for that terminal
+            # call so the driver exercises the real chain-then-await shape.
+            "return {metadata: async () => ({})};}"
             "fakeSharp.cache=function(){};"
             "module.exports=fakeSharp;\n"
         )
@@ -1454,11 +1458,18 @@ class TestHeicDecodeShim:
 
     def _run(self, tmp_path, node, env_extra, argv):
         driver = tmp_path / "driver.js"
+        # Decode is async now, so sharp(path) alone starts it but doesn't wait
+        # for it. Await metadata() per file, sequentially, so INPUT_TYPE lines
+        # land in a deterministic order regardless of decode latency — this is
+        # also exactly the chain-then-await shape Immich's own code uses.
+        awaits = "".join(
+            f"await sharp(process.argv[{i + 2}]).metadata();" for i in range(len(argv))
+        )
         driver.write_text(
             "const sharp=require('sharp');"
             "process.stdout.write('WRAPPED:'+(sharp.__heicShimWrapped===true)+'\\n');"
-            + "".join(f"sharp(process.argv[{i + 2}]);" for i in range(len(argv)))
-            + "\n"
+            f"(async () => {{{awaits}}})().catch(e => {{ console.error(e); process.exit(1); }});"
+            "\n"
         )
         env = {"PATH": "/usr/bin:/bin", **env_extra}
         return subprocess.run(
@@ -1630,6 +1641,164 @@ class TestHeicDecodeShim:
         assert (
             marker.read_text().strip() == "[" + str(real) + "]"
         ), "existing VIPSHOME must be preserved"
+
+    # --- async decode: lock-renewal-starvation regression + concurrency ---
+
+    def test_chain_calls_are_replayed_onto_real_sharp_in_order(self, tmp_path):
+        """Immich chains synchronous pipeline calls (rotate, resize, ...)
+        before awaiting a terminal method (toBuffer/toFile/metadata). Since
+        the decode is now async, sharp() can't call the real Sharp
+        synchronously anymore — it must record those chained calls and
+        replay them, in order and with their original arguments, onto the
+        real instance once decode resolves. This is the mechanism that lets
+        the decode run fully async while still looking like an ordinary
+        chainable Sharp pipeline to callers."""
+        node = self._node_or_skip()
+        sharp_dir = tmp_path / "node_modules" / "sharp"
+        sharp_dir.mkdir(parents=True)
+        (sharp_dir / "index.js").write_text(
+            "function fakeSharp(input){"
+            "const calls=[];"
+            "const inst={"
+            "rotate:(...a)=>{calls.push('rotate('+JSON.stringify(a)+')');return inst;},"
+            "resize:(...a)=>{calls.push('resize('+JSON.stringify(a)+')');return inst;},"
+            "toBuffer:async()=>{process.stdout.write('CALLS:'+calls.join(',')+'\\n');return Buffer.from('x');},"
+            "};"
+            "return inst;}"
+            "fakeSharp.cache=function(){};"
+            "module.exports=fakeSharp;\n"
+        )
+        vips = tmp_path / "vips_stub.sh"
+        self._stub(vips, self._TIFF)
+        heic = tmp_path / "photo.heic"
+        heic.write_bytes(self._HEIC_BYTES)
+        driver = tmp_path / "driver.js"
+        driver.write_text(
+            "const sharp=require('sharp');"
+            "sharp(process.argv[2]).rotate(90).resize(200,200).toBuffer()"
+            ".catch(e=>{console.error(e);process.exit(1);});\n"
+        )
+        env = {"PATH": "/usr/bin:/bin", "IMMICH_ACCELERATOR_VIPS": str(vips)}
+        result = subprocess.run(
+            [node, "--require", str(self.SHIM), str(driver), str(heic)],
+            cwd=str(tmp_path),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "CALLS:rotate([90]),resize([200,200])" in result.stdout, result.stdout
+
+    def test_decode_does_not_block_the_event_loop(self, tmp_path):
+        """The bug this fix addresses: a synchronous (execFileSync) decode
+        used to block Node's entire event loop — and with it BullMQ's
+        lock-renewal timer — for the decode's full duration
+        (#could-not-renew-lock). Prove the event loop keeps ticking during a
+        slow decode by racing a timer against it; with the old synchronous
+        decode this would report ~0 ticks."""
+        node = self._node_or_skip()
+        self._fake_sharp(tmp_path)
+        vips = tmp_path / "vips_stub.sh"
+        self._stub(vips, "sleep 0.3\n" + self._TIFF)
+        heic = tmp_path / "photo.heic"
+        heic.write_bytes(self._HEIC_BYTES)
+        driver = tmp_path / "driver.js"
+        driver.write_text(
+            "const sharp=require('sharp');"
+            "let ticks=0;"
+            "const timer=setInterval(()=>{ticks++;},20);"
+            "sharp(process.argv[2]).metadata().then(()=>{"
+            "clearInterval(timer);"
+            "process.stdout.write('TICKS:'+ticks+'\\n');"
+            "}).catch(e=>{console.error(e);process.exit(1);});\n"
+        )
+        env = {"PATH": "/usr/bin:/bin", "IMMICH_ACCELERATOR_VIPS": str(vips)}
+        result = subprocess.run(
+            [node, "--require", str(self.SHIM), str(driver), str(heic)],
+            cwd=str(tmp_path),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        assert result.returncode == 0, result.stderr
+        ticks = int(result.stdout.split("TICKS:")[1].strip())
+        assert ticks >= 5, (
+            f"event loop was blocked during decode (only {ticks} timer "
+            f"ticks in ~300ms of decode time); output: {result.stdout}"
+        )
+
+    def _run_two_concurrently(self, tmp_path, node, vips, env_extra):
+        heic1 = tmp_path / "a.heic"
+        heic1.write_bytes(self._HEIC_BYTES)
+        heic2 = tmp_path / "b.heic"
+        heic2.write_bytes(self._HEIC_BYTES)
+        driver = tmp_path / "driver.js"
+        driver.write_text(
+            "const sharp=require('sharp');"
+            "Promise.all([sharp(process.argv[2]).metadata(),sharp(process.argv[3]).metadata()])"
+            ".then(()=>process.stdout.write('DONE\\n'))"
+            ".catch(e=>{console.error(e);process.exit(1);});\n"
+        )
+        env = {"PATH": "/usr/bin:/bin", "IMMICH_ACCELERATOR_VIPS": str(vips), **env_extra}
+        return subprocess.run(
+            [node, "--require", str(self.SHIM), str(driver), str(heic1), str(heic2)],
+            cwd=str(tmp_path),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+
+    def test_decode_concurrency_defaults_to_serialized(self, tmp_path):
+        """Async execFile let BullMQ's job concurrency fire multiple
+        concurrent decodes at once; measured on a real NAS/SMB share, that
+        made things SLOWER, not faster (a modest NAS degrades under
+        concurrent reads rather than parallelizing them). Default
+        concurrency is 1 — verify two decodes issued at the same time never
+        actually overlap."""
+        node = self._node_or_skip()
+        self._fake_sharp(tmp_path)
+        lock_dir = tmp_path / "running.lock"
+        violations = tmp_path / "violations"
+        vips = tmp_path / "vips_stub.sh"
+        self._stub(
+            vips,
+            f'if ! mkdir "{lock_dir}" 2>/dev/null; then echo overlap >> "{violations}"; fi\n'
+            "sleep 0.15\n"
+            f'rmdir "{lock_dir}"\n' + self._TIFF,
+        )
+        result = self._run_two_concurrently(tmp_path, node, vips, {})
+        assert result.returncode == 0, result.stderr
+        assert "DONE" in result.stdout
+        assert (
+            not violations.exists()
+        ), "two decodes ran concurrently despite the default concurrency of 1"
+
+    def test_decode_concurrency_env_override_allows_parallel_decodes(self, tmp_path):
+        """IMMICH_ACCELERATOR_HEIC_DECODE_CONCURRENCY raises the limit for an
+        operator on storage that can actually take concurrent reads —
+        confirm it isn't a no-op by proving decodes DO overlap once raised."""
+        node = self._node_or_skip()
+        self._fake_sharp(tmp_path)
+        lock_dir = tmp_path / "running.lock"
+        overlapped = tmp_path / "overlapped"
+        vips = tmp_path / "vips_stub.sh"
+        self._stub(
+            vips,
+            f'if ! mkdir "{lock_dir}" 2>/dev/null; then touch "{overlapped}"; fi\n'
+            "sleep 0.15\n"
+            f'rmdir "{lock_dir}" 2>/dev/null\n' + self._TIFF,
+        )
+        result = self._run_two_concurrently(
+            tmp_path, node, vips, {"IMMICH_ACCELERATOR_HEIC_DECODE_CONCURRENCY": "2"}
+        )
+        assert result.returncode == 0, result.stderr
+        assert "DONE" in result.stdout
+        assert (
+            overlapped.exists()
+        ), "raising concurrency to 2 should let two decodes run at once"
 
 
 class TestPgKeepaliveShim:


### PR DESCRIPTION
The decode shim ran synchronously (`execFileSync`), blocking the worker's event loop — and BullMQ's lock-renewal timer with it — for the decode's full duration. A previous fix shrank the timeout to stop that starvation, but on a NAS-backed library (SMB) a legitimate decode can take 20+ seconds, so it just traded "occasionally slow" for "permanently broken."

The decoder now runs via async `execFile`, so a slow decode never blocks the event loop, and the timeout is a generous hang-safety ceiling instead. Going async let BullMQ run decodes concurrently, which measurably made things worse on this NAS (4 concurrent `vips` decodes: 37s+ vs 20.7s for one alone), so decode concurrency is capped at 1 by default (`IMMICH_ACCELERATOR_HEIC_DECODE_CONCURRENCY` to raise it).

Verified live: a HEIC that failed every attempt for 2 days now decodes in 21.4s with the event loop confirmed never blocked.

## Test plan
- [x] `pytest -v -m "not slow"` passes
- [x] New regression tests: event loop not blocked during decode, chain calls replayed correctly, concurrency defaults to 1 and is overridable
- [x] Verified each new test fails against the pre-fix code and passes against the fix