### PR TITLE
Add job retry shim: unlimited attempts, backoff resets on restart

### DIFF
--- a/immich_accelerator/__main__.py
+++ b/immich_accelerator/__main__.py
@@ -4780,6 +4780,20 @@ def _cmd_start(args):
             f"{existing} {require_arg}".strip() if existing else require_arg
         )
 
+    # job retry shim: Immich hardcodes `attempts: 1` (no retry) for every
+    # BullMQ queue. In a split deployment a transient connection drop to a
+    # remote Postgres/Redis or a brief SMB hiccup permanently fails the job
+    # instead of retrying. We wrap `bullmq`'s Queue constructor to raise the
+    # attempt count with exponential backoff. Same --require interposition;
+    # Immich's source is untouched.
+    job_retry_shim = Path(__file__).parent / "hooks" / "job_retry_shim.js"
+    if job_retry_shim.exists():
+        existing = worker_env.get("NODE_OPTIONS", "").strip()
+        require_arg = f'--require "{job_retry_shim}"'
+        worker_env["NODE_OPTIONS"] = (
+            f"{existing} {require_arg}".strip() if existing else require_arg
+        )
+
     # /build link points to our build-data dir (set up during setup).
     # Required for Immich 2.7+ plugin WASM paths stored in the shared DB.
     build_data = DATA_DIR / "build-data"

--- a/immich_accelerator/hooks/job_retry_shim.js
+++ b/immich_accelerator/hooks/job_retry_shim.js
@@ -1,0 +1,163 @@
+// job_retry_shim.js
+//
+// Runtime interposition to give Immich's BullMQ queues automatic retries
+// that never permanently fail, with exponential backoff that resets to its
+// short initial delay whenever the accelerator restarts.
+//
+// Immich hardcodes `defaultJobOptions: { attempts: 1, ... }` for every queue
+// (config.repository.js), so any single failure — a dropped connection to a
+// remote Postgres/Redis in a split deployment, a transient SMB hiccup on the
+// library mount — permanently fails the job with zero retry. There's no env
+// var for this; it's baked into the object Immich builds and hands to
+// `BullModule.forRoot()`. Rather than patch Immich's source (which would
+// break the "unmodified" invariant), we preload this module via
+// `NODE_OPTIONS=--require ...` and interpose on two points in `bullmq`.
+//
+// Neither `Queue` nor `Worker` can be wrapped at the constructor/export
+// level: bullmq's compiled CJS index re-exports both via tslib's
+// __exportStar, which defines them as getters with `configurable: false`
+// (ESM live-binding emulation) — empirically verified against the real
+// installed package, both plain assignment and Object.defineProperty throw.
+// So instead:
+//
+//   1. `Queue.prototype.add`/`addBulk` (ordinary writable, configurable
+//      methods) are wrapped to inject a very high `attempts` ceiling and a
+//      custom backoff marker into every job's options, unless the caller
+//      already asked for something explicit.
+//
+//   2. The actual retry delay is decided worker-side, not queue-side:
+//      `Job.shouldRetryJob()` reads `this.queue.opts.settings.backoffStrategy`,
+//      and for a job being processed `this.queue` is the *Worker* instance
+//      (`Worker extends QueueBase`; `Job.fromJSON(this, ...)` is called with
+//      `this` bound to the Worker) — not the producer-side Queue object, and
+//      `@nestjs/bullmq` builds each Worker its own fresh options object that
+//      never inherits the Queue's `defaultJobOptions`/`settings`. So we wrap
+//      `Worker.prototype.run` (called once per worker, before it processes
+//      anything) to inject our backoff strategy into `this.opts.settings`.
+//
+// The backoff strategy itself tracks attempt counts in a process-local Map
+// keyed by `queueName:jobId`, deliberately ignoring bullmq's own
+// Redis-persisted `attemptsMade` (which never resets). A restart clears the
+// Map along with the rest of the process's memory, so any job that was deep
+// into a long backoff before the restart starts ramping from the short
+// initial delay again — appropriate here, since a restart usually means
+// whatever connection was flaky got a fresh start too. Delay is capped so a
+// job that keeps failing in a single long-running process still gets
+// retried at a bounded interval instead of the uncapped 2^n growth of
+// bullmq's builtin `exponential` strategy.
+//
+// A job that keeps failing for a real reason (corrupt file, permanently
+// missing asset) will keep retrying forever rather than ending up
+// permanently "failed" — that's the intended behavior for this shim, at the
+// cost of never getting a clean signal to stop trying. Off the hot path
+// relative to actual image processing. Opt-out / tune via env (see below).
+
+'use strict';
+
+const ENABLED = process.env.IMMICH_ACCEL_JOB_RETRY !== '0';
+// Effectively unlimited by default — bullmq requires a finite number, and
+// this is high enough that no real job will ever exhaust it.
+const ATTEMPTS = parseInt(
+    process.env.IMMICH_ACCEL_JOB_RETRY_ATTEMPTS || String(Number.MAX_SAFE_INTEGER), 10
+);
+const BASE_MS = parseInt(
+    process.env.IMMICH_ACCEL_JOB_RETRY_BACKOFF_MS || '10000', 10
+);
+const MAX_MS = parseInt(
+    process.env.IMMICH_ACCEL_JOB_RETRY_BACKOFF_MAX_MS || String(5 * 60 * 1000), 10
+);
+const BACKOFF_TYPE = 'immich-accel';
+
+// Process-local attempt counter, keyed by `queueName:jobId`. Not bullmq's
+// `attemptsMade` (Redis-persisted, never resets) — deliberately reset by a
+// process restart. Bounded so a long-running process can't leak memory
+// tracking every job id it has ever seen; clearing it early just means a
+// handful of jobs mid-backoff restart their ramp, which is harmless.
+const localAttempts = new Map();
+const MAX_TRACKED = 50000;
+
+function backoffStrategy(_attemptsMade, _type, _err, job) {
+    if (localAttempts.size > MAX_TRACKED) {
+        localAttempts.clear();
+    }
+    const queueName = (job && job.queueName) || (job && job.queue && job.queue.name) || '?';
+    const key = `${queueName}:${job && job.id}`;
+    const n = (localAttempts.get(key) || 0) + 1;
+    localAttempts.set(key, n);
+    return Math.min(BASE_MS * Math.pow(2, n - 1), MAX_MS);
+}
+
+function withRetry(opts) {
+    // add()/addBulk() accept opts as an object (or undefined/null). Only
+    // augment the object form, and never override an explicit choice the
+    // caller already made — Immich's own value here is what we intend to
+    // override, but a future Immich version setting something other than
+    // the current hardcoded default (or a caller in a test harness) should
+    // win.
+    const next = opts && typeof opts === 'object' ? { ...opts } : {};
+    if (next.attempts === undefined || next.attempts === 1) {
+        next.attempts = ATTEMPTS;
+    }
+    if (next.backoff === undefined) {
+        next.backoff = { type: BACKOFF_TYPE };
+    }
+    return next;
+}
+
+function patchQueuePrototype(QueueProto) {
+    const origAdd = QueueProto.add;
+    QueueProto.add = function (name, data, opts) {
+        return origAdd.call(this, name, data, withRetry(opts));
+    };
+
+    const origAddBulk = QueueProto.addBulk;
+    QueueProto.addBulk = function (jobs) {
+        const next = jobs.map((job) => ({ ...job, opts: withRetry(job.opts) }));
+        return origAddBulk.call(this, next);
+    };
+}
+
+function patchWorkerPrototype(WorkerProto) {
+    const origRun = WorkerProto.run;
+    WorkerProto.run = function (...args) {
+        if (!this.opts) this.opts = {};
+        if (!this.opts.settings) this.opts.settings = {};
+        if (!this.opts.settings.backoffStrategy) {
+            this.opts.settings.backoffStrategy = backoffStrategy;
+        }
+        return origRun.apply(this, args);
+    };
+}
+
+function patchBullmq(bullmq) {
+    if (bullmq.Queue && bullmq.Queue.prototype && bullmq.Queue.prototype.add) {
+        patchQueuePrototype(bullmq.Queue.prototype);
+    }
+    if (bullmq.Worker && bullmq.Worker.prototype && bullmq.Worker.prototype.run) {
+        patchWorkerPrototype(bullmq.Worker.prototype);
+    }
+    process.stderr.write(
+        `[immich-accelerator] job retry enabled (attempts effectively unlimited, ` +
+        `backoff ${BASE_MS}ms exponential capped at ${MAX_MS}ms, resets on restart)\n`
+    );
+}
+
+if (ENABLED) {
+    const Module = require('module');
+    const origLoad = Module._load;
+    Module._load = function (request, parent, isMain) {
+        const mod = origLoad.apply(this, arguments);
+        if (request === 'bullmq' && mod && !mod.__jobRetryPatched) {
+            try {
+                patchBullmq(mod);
+                mod.__jobRetryPatched = true;
+            } catch (e) {
+                process.stderr.write(
+                    '[immich-accelerator] job retry shim failed: ' +
+                    String((e && e.message) || e) + '\n'
+                );
+            }
+        }
+        return mod;
+    };
+}

--- a/tests/test_fresh_install.py
+++ b/tests/test_fresh_install.py
@@ -2178,3 +2178,256 @@ class TestPgKeepaliveShim:
         )
         assert result.returncode == 0, result.stderr
         assert "KEEPALIVE:undefined" in result.stdout, result.stdout
+
+
+class TestJobRetryShim:
+    """The job retry shim gives BullMQ jobs an effectively unlimited attempt
+    count with exponential backoff that resets whenever the accelerator
+    restarts. Immich hardcodes `attempts: 1` (no retry) for every queue
+    (config.repository.js), so a transient connection drop in a split
+    deployment permanently fails the job. Immich's source is never touched —
+    the shim interposes on `bullmq` via NODE_OPTIONS=--require.
+
+    It can't wrap the `Queue`/`Worker` constructors or exports: empirically,
+    against the real installed bullmq package,
+    `Object.getOwnPropertyDescriptor(bullmq, 'Queue')` (same for `Worker`) is
+    `{ configurable: false, get: fn, set: undefined }` — tslib's
+    __exportStar re-export of a star-exported class. Both plain assignment
+    and Object.defineProperty throw against that descriptor. The fake
+    `bullmq` module below reproduces that exact non-configurable getter shape
+    so this class of bug (caught only by testing against the real package,
+    not the first version of this test) can't silently regress.
+
+    The retry *count* is set producer-side, by wrapping
+    `Queue.prototype.add`/`addBulk`. The retry *delay* has to be set
+    worker-side: `Job.shouldRetryJob()` reads
+    `this.queue.opts.settings.backoffStrategy`, and for a job being
+    processed `this.queue` is the *Worker* instance handling it (verified
+    against bullmq's source — `Worker extends QueueBase`, and
+    `Job.fromJSON(this, ...)` is called with `this` bound to the Worker), not
+    the producer Queue object `@nestjs/bullmq` originally constructed. So the
+    shim also wraps `Worker.prototype.run` to inject the backoff strategy
+    there before the worker starts processing.
+    """
+
+    SHIM_PATH = REPO_ROOT / "immich_accelerator" / "hooks" / "job_retry_shim.js"
+
+    @staticmethod
+    def _write_fake_bullmq(bullmqdir):
+        # add()/addBulk() echo back the opts they received; run() returns the
+        # backoffStrategy the shim installed, both so the test can assert on
+        # exactly what the shim injected. Real bullmq does far more (tracing,
+        # Redis calls, actual job processing); none of that matters here —
+        # this shim only touches options objects on the way in.
+        bullmqdir.mkdir(parents=True)
+        (bullmqdir / "index.js").write_text(
+            "class Queue {\n"
+            "  constructor(name, opts){ this.name = name; this.opts = opts || {}; }\n"
+            "  add(name, data, opts){ return { name, opts }; }\n"
+            "  addBulk(jobs){ return jobs.map(j => ({ name: j.name, opts: j.opts })); }\n"
+            "}\n"
+            "class Worker {\n"
+            "  constructor(name, processor, opts){ this.name = name; this.opts = opts || {}; }\n"
+            "  run(){ return this.opts.settings && this.opts.settings.backoffStrategy; }\n"
+            "}\n"
+            # Getter-only, non-configurable — matches the real installed
+            # bullmq package's compiled CJS index exactly (verified via
+            # Object.getOwnPropertyDescriptor against node_modules/bullmq).
+            "Object.defineProperty(exports, 'Queue', {\n"
+            "  get() { return Queue; }, enumerable: true, configurable: false,\n"
+            "});\n"
+            "Object.defineProperty(exports, 'Worker', {\n"
+            "  get() { return Worker; }, enumerable: true, configurable: false,\n"
+            "});\n"
+        )
+
+    def test_shim_file_exists(self):
+        assert self.SHIM_PATH.exists(), f"hook shim missing: {self.SHIM_PATH}"
+
+    def test_shim_is_referenced_by_cmd_start(self):
+        src = (REPO_ROOT / "immich_accelerator" / "__main__.py").read_text()
+        assert "job_retry_shim.js" in src
+        assert "NODE_OPTIONS" in src
+
+    def test_shim_syntax_valid(self):
+        import shutil
+
+        node = shutil.which("node")
+        if not node:
+            pytest.skip("node not installed")
+        result = subprocess.run(
+            [node, "--check", str(self.SHIM_PATH)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0, f"shim syntax error: {result.stderr}"
+
+    @pytest.mark.slow
+    def test_shim_raises_attempts_via_add_and_addbulk(self, tmp_path):
+        """add()/addBulk() should get an effectively unlimited attempts count
+        and a backoff marker injected when the caller didn't ask for
+        anything explicit, the way Immich's job.repository.js calls them —
+        while an explicit caller-set attempts count survives untouched."""
+        import shutil
+
+        node = shutil.which("node")
+        if not node:
+            pytest.skip("node not installed")
+
+        bullmqdir = tmp_path / "node_modules" / "bullmq"
+        self._write_fake_bullmq(bullmqdir)
+
+        caller = tmp_path / "caller.js"
+        caller.write_text(
+            "const { Queue } = require('bullmq');\n"
+            "const q = new Queue('thumbnailGeneration', {\n"
+            "  defaultJobOptions: { attempts: 1, removeOnComplete: true, removeOnFail: false }\n"
+            "});\n"
+            # No per-call opts (Immich's actual call shape) — should pick up defaults.
+            "const r1 = q.add('metadata-extraction', {}, {});\n"
+            "console.log('ATTEMPTS:' + r1.opts.attempts);\n"
+            "console.log('BACKOFF_TYPE:' + r1.opts.backoff.type);\n"
+            # An explicit non-default attempts count must survive untouched.
+            "const r2 = q.add('x', {}, { attempts: 5 });\n"
+            "console.log('EXPLICIT_ATTEMPTS:' + r2.opts.attempts);\n"
+            # addBulk: first job gets defaults, second job's explicit count survives.
+            "const bulk = q.addBulk([\n"
+            "  { name: 'a', data: {}, opts: {} },\n"
+            "  { name: 'b', data: {}, opts: { attempts: 7 } },\n"
+            "]);\n"
+            "console.log('BULK_A_ATTEMPTS:' + bulk[0].opts.attempts);\n"
+            "console.log('BULK_B_ATTEMPTS:' + bulk[1].opts.attempts);\n"
+        )
+        result = subprocess.run(
+            [node, "--require", str(self.SHIM_PATH), str(caller)],
+            cwd=str(tmp_path),
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+        out = result.stdout
+        assert f"ATTEMPTS:{2**53 - 1}" in out, out  # Number.MAX_SAFE_INTEGER — "never expires"
+        assert "BACKOFF_TYPE:immich-accel" in out, out
+        assert "EXPLICIT_ATTEMPTS:5" in out, out  # never override a real explicit choice
+        assert f"BULK_A_ATTEMPTS:{2**53 - 1}" in out, out
+        assert "BULK_B_ATTEMPTS:7" in out, out
+
+    @pytest.mark.slow
+    def test_shim_disabled_via_env(self, tmp_path):
+        import shutil
+
+        node = shutil.which("node")
+        if not node:
+            pytest.skip("node not installed")
+        bullmqdir = tmp_path / "node_modules" / "bullmq"
+        self._write_fake_bullmq(bullmqdir)
+        caller = tmp_path / "caller.js"
+        caller.write_text(
+            "const { Queue } = require('bullmq');\n"
+            "const q = new Queue('x', { defaultJobOptions: { attempts: 1 } });\n"
+            "const r = q.add('x', {}, {});\n"
+            "console.log('ATTEMPTS:' + r.opts.attempts);\n"
+        )
+        result = subprocess.run(
+            [node, "--require", str(self.SHIM_PATH), str(caller)],
+            cwd=str(tmp_path),
+            env={"IMMICH_ACCEL_JOB_RETRY": "0", "PATH": "/usr/bin:/bin"},
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "ATTEMPTS:undefined" in result.stdout, result.stdout
+
+    @pytest.mark.slow
+    def test_backoff_strategy_is_capped_exponential_per_job(self, tmp_path):
+        """Worker.prototype.run must have the shim's backoff strategy
+        installed in opts.settings. Calling it repeatedly for the same job
+        should grow exponentially from the configured base delay, capped at
+        the configured max — never bullmq's own uncapped 2^n growth — while
+        a different job id starts its own count from the base delay."""
+        import shutil
+
+        node = shutil.which("node")
+        if not node:
+            pytest.skip("node not installed")
+        bullmqdir = tmp_path / "node_modules" / "bullmq"
+        self._write_fake_bullmq(bullmqdir)
+        caller = tmp_path / "caller.js"
+        caller.write_text(
+            "const { Worker } = require('bullmq');\n"
+            "const w = new Worker('thumbnailGeneration', null, {});\n"
+            "const strategy = w.run();\n"
+            "console.log('HAS_STRATEGY:' + (typeof strategy === 'function'));\n"
+            "const jobA = { id: '1', queueName: 'thumbnailGeneration' };\n"
+            "const jobB = { id: '2', queueName: 'thumbnailGeneration' };\n"
+            "console.log('A1:' + strategy(undefined, undefined, undefined, jobA));\n"
+            "console.log('A2:' + strategy(undefined, undefined, undefined, jobA));\n"
+            "console.log('A3:' + strategy(undefined, undefined, undefined, jobA));\n"
+            # A different job id must not inherit jobA's ramp.
+            "console.log('B1:' + strategy(undefined, undefined, undefined, jobB));\n"
+        )
+        result = subprocess.run(
+            [node, "--require", str(self.SHIM_PATH), str(caller)],
+            cwd=str(tmp_path),
+            env={
+                "IMMICH_ACCEL_JOB_RETRY_BACKOFF_MS": "1000",
+                "IMMICH_ACCEL_JOB_RETRY_BACKOFF_MAX_MS": "3000",
+                "PATH": "/usr/bin:/bin",
+            },
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+        out = result.stdout
+        assert "HAS_STRATEGY:true" in out, out
+        assert "A1:1000" in out, out  # base delay
+        assert "A2:2000" in out, out  # 1000 * 2^1
+        assert "A3:3000" in out, out  # 1000 * 2^2 = 4000, capped at 3000
+        assert "B1:1000" in out, out  # independent counter, starts fresh
+
+    @pytest.mark.slow
+    def test_backoff_resets_across_process_restarts(self, tmp_path):
+        """The whole point of tracking attempts in a process-local Map
+        instead of bullmq's Redis-persisted attemptsMade: a fresh process
+        (standing in for the accelerator restarting) must ramp from the
+        short base delay again for a job id it has never seen before in
+        *this* process, even though the job may have failed many times
+        against the previous process."""
+        import shutil
+
+        node = shutil.which("node")
+        if not node:
+            pytest.skip("node not installed")
+        bullmqdir = tmp_path / "node_modules" / "bullmq"
+        self._write_fake_bullmq(bullmqdir)
+        caller = tmp_path / "caller.js"
+        caller.write_text(
+            "const { Worker } = require('bullmq');\n"
+            "const w = new Worker('q', null, {});\n"
+            "const strategy = w.run();\n"
+            "const job = { id: '42', queueName: 'q' };\n"
+            # Simulate several prior failures within one process lifetime.
+            "strategy(undefined, undefined, undefined, job);\n"
+            "strategy(undefined, undefined, undefined, job);\n"
+            "console.log('DELAY:' + strategy(undefined, undefined, undefined, job));\n"
+        )
+        env = {"IMMICH_ACCEL_JOB_RETRY_BACKOFF_MS": "1000", "PATH": "/usr/bin:/bin"}
+        run1 = subprocess.run(
+            [node, "--require", str(self.SHIM_PATH), str(caller)],
+            cwd=str(tmp_path), env=env, capture_output=True, text=True, timeout=15,
+        )
+        run2 = subprocess.run(
+            [node, "--require", str(self.SHIM_PATH), str(caller)],
+            cwd=str(tmp_path), env=env, capture_output=True, text=True, timeout=15,
+        )
+        assert run1.returncode == 0, run1.stderr
+        assert run2.returncode == 0, run2.stderr
+        # 3rd call for the same job id: 1000 * 2^2 = 4000, in both processes —
+        # a real "remembers across restarts" bug would show run2 continuing
+        # past where run1 left off instead of restarting at the same value.
+        assert "DELAY:4000" in run1.stdout, run1.stdout
+        assert "DELAY:4000" in run2.stdout, run2.stdout


### PR DESCRIPTION
## What this changes

Immich hardcodes `defaultJobOptions: { attempts: 1 }` for every BullMQ queue (`config.repository.js`), so any single transient failure — a dropped connection to a remote Postgres/Redis in a split deployment, a brief SMB hiccup on the library mount — permanently fails the job with zero retry. That's how assets end up permanently stuck showing "Error loading image" after nothing more than a momentary network blip: the thumbnail-generation job exhausts its one and only attempt and never runs again.

This adds a `NODE_OPTIONS=--require` interposition shim (same pattern as the existing `pg_dump`/HEIC/`pg_keepalive` shims — Immich's source is never touched) that:

- Wraps `Queue.prototype.add`/`addBulk` to give every job an effectively unlimited attempts ceiling, so a job never reaches permanent "failed" purely from exhausting retries.
- Wraps `Worker.prototype.run` to install a custom backoff strategy. This has to be worker-side, not queue-side: `Job.shouldRetryJob()` reads `this.queue.opts.settings.backoffStrategy`, and for a job being processed `this.queue` is the *Worker* instance handling it (`Worker extends QueueBase`; `Job.fromJSON(this, ...)` binds `this` to the Worker) — not the producer `Queue` object. `@nestjs/bullmq` gives each Worker its own fresh options that never inherit the Queue's `defaultJobOptions`/`settings`, so patching the Queue side alone has no effect on retry timing.
- Tracks attempt counts in a process-local `Map` keyed by `queueName:jobId` instead of bullmq's Redis-persisted `attemptsMade` (which never resets), so restarting the accelerator naturally resets any job's backoff ramp back to the short initial delay. Delay is capped so a job that keeps failing within one long-running process still retries at a bounded interval instead of growing unboundedly.

**Why not wrap the `Queue`/`Worker` constructors directly**, the way `pg_keepalive_shim.js` wraps `pg`'s `Pool`/`Client`? bullmq's compiled CJS index re-exports both classes via tslib's `__exportStar`, which defines them as **non-configurable getters** (ESM live-binding emulation) — empirically confirmed against the real installed package (`Object.getOwnPropertyDescriptor(bullmq, 'Queue')` → `{ configurable: false, get: fn }`). Both plain assignment and `Object.defineProperty` throw against that descriptor. I only caught this by deploying to a live worker — the first version of the test suite used a plain mutable fake `bullmq` module and missed it entirely. The fixtures now reproduce bullmq's actual non-configurable getter shape so this class of bug gets caught by the suite instead of only in production.

Verified end-to-end against a real worker with a live split deployment: 43 assets permanently stuck in "Error loading image" (`thumbnailGeneration` jobs that had exhausted Immich's hardcoded `attempts: 1` during a bout of Redis/Postgres connection instability) cleared to 0 failed once retries could actually run.

Tunable via env: `IMMICH_ACCEL_JOB_RETRY` (default on), `IMMICH_ACCEL_JOB_RETRY_ATTEMPTS`, `IMMICH_ACCEL_JOB_RETRY_BACKOFF_MS` (default 10s), `IMMICH_ACCEL_JOB_RETRY_BACKOFF_MAX_MS` (default 5min cap).

## Checklist

- [x] Ran `pytest -v -m "not slow"` locally — 382 passed. 7 pre-existing failures (PID-management and one dashboard test) reproduce identically on a clean `origin/main` checkout with none of this branch's changes applied — real PIDs on this dev machine colliding with test fixtures, not something a clean CI runner should hit. Unrelated to this change.
- [x] Tested on a real Mac with the accelerator running (this is where the bug and fix were both found — see above)
- [x] No unrelated changes bundled in
