### PR TITLE
Add "Mount NAS shares at login" toggle to menu bar Settings

### DIFF
--- a/menubar/Sources/AcceleratorBar/Actions.swift
+++ b/menubar/Sources/AcceleratorBar/Actions.swift
@@ -11,6 +11,58 @@ enum LaunchAtLogin {
     }
 }
 
+// Remembers which SMB shares were mounted when the user turned this on, and
+// remounts any that go missing at every launch. macOS drops NAS shares
+// silently under network/sleep churn (see split-deployment troubleshooting);
+// remounting is a manual "Connect to Server" nobody remembers to redo after
+// a wake, so photos quietly stop processing — worker.log fills with ENOENT
+// on every file the worker touches, but nothing in the UI says why.
+enum MountSharesAtLogin {
+    private static let key = "MountSharesAtLoginURLs"
+
+    static var isEnabled: Bool { UserDefaults.standard.array(forKey: key) != nil }
+
+    // Turning it on snapshots whichever SMB shares are mounted right now.
+    // Turning it off forgets that list — re-enabling later re-snapshots
+    // rather than remounting something the user may have unmounted on purpose.
+    static func set(_ on: Bool) async {
+        if on {
+            let (_, out) = await Actions.run("/sbin/mount", [])
+            UserDefaults.standard.set(smbURLs(fromMountOutput: out), forKey: key)
+        } else {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+    }
+
+    // Parses `mount` for smbfs lines, e.g.
+    //   //pi@192.168.1.2/immich on /Volumes/immich (smbfs, nodev, nosuid, ...)
+    // into smb:// URLs NSWorkspace can hand back to Finder for a remount.
+    static func smbURLs(fromMountOutput out: String) -> [String] {
+        out.split(separator: "\n").compactMap { line -> String? in
+            guard line.contains("(smbfs"), let onRange = line.range(of: " on /Volumes/") else {
+                return nil
+            }
+            let remote = line[line.startIndex..<onRange.lowerBound]
+            guard remote.hasPrefix("//") else { return nil }
+            return "smb:" + remote
+        }
+    }
+
+    // Called once at launch. Best-effort and silent: `open` hands off to
+    // Finder/diskarbitrationd, which only prompts for credentials if none
+    // were saved to Keychain from the share's original manual mount.
+    static func remountMissing() {
+        guard let urls = UserDefaults.standard.array(forKey: key) as? [String] else { return }
+        for urlString in urls {
+            guard let shareName = urlString.split(separator: "/").last else { continue }
+            let mountPoint = "/Volumes/\(shareName)"
+            guard !FileManager.default.fileExists(atPath: mountPoint),
+                  let url = URL(string: urlString) else { continue }
+            NSWorkspace.shared.open(url)
+        }
+    }
+}
+
 // Daily actions, shelling out to the same commands a user would run.
 enum Actions {
     static let brew = "/opt/homebrew/bin/brew"

--- a/menubar/Sources/AcceleratorBar/App.swift
+++ b/menubar/Sources/AcceleratorBar/App.swift
@@ -129,6 +129,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if !Paths.isConfigured {
             WindowManager.shared.showOnboarding(model: .shared)
         }
+        // No-op unless "Mount NAS shares at login" is on; cheap enough
+        // (an existence check per remembered share) to run unconditionally.
+        MountSharesAtLogin.remountMissing()
         // Keep the core in lockstep: if this (possibly Sparkle-updated) app is
         // newer than the installed core, pull the core forward, always, no
         // prompt. So a Sparkle update upgrades the whole accelerator.

--- a/menubar/Sources/AcceleratorBar/SettingsView.swift
+++ b/menubar/Sources/AcceleratorBar/SettingsView.swift
@@ -80,6 +80,7 @@ struct SettingsView: View {
     @State private var applyingComponent: String?
     @State private var componentError: String?
     @State private var launchAtLogin = LaunchAtLogin.isEnabled
+    @State private var mountSharesAtLogin = MountSharesAtLogin.isEnabled
 
     var body: some View {
         NavigationSplitView {
@@ -165,6 +166,18 @@ struct SettingsView: View {
             Section {
                 Toggle("Launch menu bar at login", isOn: $launchAtLogin)
                     .onChange(of: launchAtLogin) { _, on in LaunchAtLogin.set(on) }
+
+                VStack(alignment: .leading, spacing: Metrics.xs) {
+                    Toggle("Mount NAS shares at login", isOn: $mountSharesAtLogin)
+                        .onChange(of: mountSharesAtLogin) { _, on in
+                            Task { await MountSharesAtLogin.set(on) }
+                        }
+                    // Turning this on remembers whatever SMB shares (e.g. a
+                    // NAS backing a split deployment) are mounted right now;
+                    // it doesn't ask which ones separately.
+                    Text("Remembers the SMB shares mounted right now and reconnects any that are missing on launch.")
+                        .font(.rowDetail).foregroundStyle(.secondary)
+                }
             } header: {
                 Text("Startup")
             } footer: {


### PR DESCRIPTION
## What this changes

macOS drops SMB shares silently under network/sleep churn. Seen live today, mid-session, while diagnosing a separate "photos stuck processing" issue: `/Volumes/immich` (backing a split deployment's `/data` mount) vanished entirely — the Pi it points at stayed fully reachable (clean ping, SMB port 445 open), no crash, no error dialog, the mount just wasn't there anymore. Every worker job touching `/data` failed instantly on `ENOENT`. Reconnecting was a manual Finder "Connect to Server," which is easy to forget after a wake — the failure mode is quiet (jobs just don't progress) with nothing pointing at "your NAS share is unmounted" as the cause.

Adds a **"Mount NAS shares at login"** toggle to Settings → General → Startup, next to the existing "Launch menu bar at login":

- Turning it on snapshots whichever SMB shares (`//user@host/share`) are mounted right now into `UserDefaults`.
- `AppDelegate.applicationDidFinishLaunching` calls `MountSharesAtLogin.remountMissing()` unconditionally (a no-op — one `FileManager.fileExists` check per remembered share — unless the toggle was ever turned on), and for any remembered share whose `/Volumes/<name>` mountpoint is currently absent, hands the corresponding `smb://` URL to `NSWorkspace.shared.open(...)`. Same mechanism `Actions.openImmich` already uses for arbitrary URLs, and the same handoff a manual Finder mount uses — so a share with credentials already saved in Keychain reconnects silently, with no dialog.
- Turning it off forgets the remembered list rather than leaving it to remount something the user may have deliberately unmounted.

## Permissions

No new entitlements. The app is already unsandboxed (`scripts/build_app.sh` states this explicitly). `Process()` running `/sbin/mount` (read-only, lists volumes) reuses the exact same `Actions.run` helper already used for `brew services start/stop`; `NSWorkspace.shared.open(smb://...)` reuses the same API `Actions.openImmich` uses for `http://` URLs; `FileManager.fileExists` on a mountpoint is a `stat()`, not a directory listing, and isn't one of the TCC-protected categories. The one real consideration, not a permission: if a share's Keychain credentials aren't saved, `NSWorkspace.open` pops Finder's own auth dialog unprompted at login — opt-in, and it mirrors exactly what a manual Finder mount already does.

## Checklist

- [x] Ran `pytest -v -m "not slow"` locally — 379 passed, same 7 pre-existing failures unrelated to this change (see PR #129 for detail on those). This is a Swift-only change; the Python suite doesn't exercise it.
- [x] `swift build` succeeds cleanly in `menubar/`
- [x] The SMB `mount` output parser (`MountSharesAtLogin.smbURLs(fromMountOutput:)`) was checked against real `mount` output captured live from the affected Mac during the incident above, not synthetic data
- [ ] Tested end-to-end on a real Mac (build verified; live toggle-and-reconnect walkthrough not yet done by a human — flagging so a reviewer can do that pass)
- [x] No unrelated changes bundled in
