### PR TITLE
Fix dashboard showing "done" while a task's queue is still active

### DIFF
--- a/immich_accelerator/dashboard.html
+++ b/immich_accelerator/dashboard.html
@@ -432,10 +432,14 @@ function render(d) {
       let rateText;
       if (rate > 0) {
         rateText = rate + '/min' + (eta ? ' \u00b7 ' + eta : '') + (qc > 0 ? ' \u00b7 ' + qc + ' queued' : '');
+      } else if (qActive) {
+        // Checked before the pct>=99.9 "done" branch below: a queue that's
+        // still active (jobs re-queued for already-processed assets, a fresh
+        // upload not yet counted in the DB total) must never render "done"
+        // just because the DB-derived ratio happens to already be ~100%.
+        rateText = 'processing' + (qc > 0 ? ' \u00b7 ' + qc + ' queued' : '');
       } else if (p.pct >= 99.9) {
         rateText = 'done';
-      } else if (qActive) {
-        rateText = 'processing' + (qc > 0 ? ' \u00b7 ' + qc + ' queued' : '');
       } else if (noApi && p.done < p.total) {
         rateText = d.jobs_api_error ? 'no job data: ' + d.jobs_api_error : 'no job data (check api_key in config)';
       } else {

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -613,3 +613,25 @@ class TestFastAPIApp:
             data = resp.json()
             for v in data.values():
                 assert v == "ok"
+
+
+class TestDashboardHtmlDoneLabel:
+    """dashboard.html's per-task rateText decision (chip.tasks.forEach) must
+    never render 'done' while Immich's job queue is still active for that
+    task. The DB-derived pct (asset markers already set) can reach ~100%
+    while a queue is genuinely still running — a fresh upload not yet
+    counted in the DB total, or jobs re-queued for already-processed assets
+    (e.g. after a retry). Regression guard for exactly that: 'accelerator
+    dashboard shows done but there are pending/waiting items'."""
+
+    HTML_PATH = Path(__file__).parent.parent / "immich_accelerator" / "dashboard.html"
+
+    def test_qactive_checked_before_pct_done(self):
+        src = self.HTML_PATH.read_text()
+        qactive_branch = src.index("} else if (qActive) {")
+        pct_done_branch = src.index("} else if (p.pct >= 99.9) {")
+        assert qactive_branch < pct_done_branch, (
+            "the qActive branch must come before the pct>=99.9 'done' branch "
+            "in dashboard.html's rateText chain, or a still-active queue "
+            "renders as 'done' whenever the DB-derived ratio is already ~100%"
+        )


### PR DESCRIPTION
## What this changes

`dashboard.html`'s per-task status label (`chip.tasks.forEach`, computing `rateText`) checked `p.pct >= 99.9` *before* checking `qActive` (whether Immich's job queue actually has active/waiting items for that specific task). Once a stage's DB-derived done/total ratio was already near 100%, it rendered **"done" unconditionally** — even with jobs genuinely queued or actively running for that exact stage: a fresh upload not yet reflected in the DB total, or work re-queued after a retry. The `queue_active`/`queue_counts` data needed to know better was already present in the `/api/status` payload (`dashboard.py`); the display logic just consulted it too late in the `if`/`else if` chain.

This is the same class of issue the `1.9.0` changelog documents fixing once already ("The dashboard reported 100% complete while assets were still unprocessed") — that fix addressed the *pct calculation itself* (previously flat-100%'d whenever a queue was idle); this one is in the separate *label* logic layered on top of the corrected pct, which still had its own ordering bug.

Fix: swap the branch order. An active queue (`qActive`) now always renders `"processing · N queued"` regardless of how close to 100% the DB ratio already is; `"done"` only shows once that queue has actually drained.

## Checklist

- [x] Ran `pytest -v -m "not slow"` locally — 380 passed. Same 7 pre-existing failures as PR #129/#130 (PID-management tests colliding with real PIDs on this dev machine, plus one unrelated dashboard test) — reproduce identically on a clean `origin/main` checkout, unrelated to this change.
- [x] Tested on a real Mac with the accelerator running: reproduced the bug live (a library at ~99.96% done with a genuine active re-queued backlog showing "done"), confirmed the fix by curling the running dashboard's served HTML post-edit (`_load_html()` reads the file fresh per request, no restart needed) and re-observing the corrected label against the real, still-live backlog.
- [x] No unrelated changes bundled in
