### PR TITLE
Make the test suite pass on a Mac that runs the accelerator

### DIFF
--- a/immich_accelerator/__main__.py
+++ b/immich_accelerator/__main__.py
@@ -101,6 +101,11 @@ _ml_foreign_listener_warned = False
 
 
 SYNTHETIC_CONF = Path("/etc/synthetic.d/immich-accelerator")
+# Pre-1.3.3 installs put the entry here instead, and uninstall still has to
+# clean it out. A constant rather than two literals, so tests can point it
+# somewhere harmless: it is a shared system file that other software writes to,
+# and the code rewrites it through `sudo tee`.
+LEGACY_SYNTHETIC_CONF = Path("/etc/synthetic.conf")
 
 
 def _build_link_ok() -> bool:
@@ -196,7 +201,7 @@ def _ensure_build_link():
     if _build_link_ok():
         # Migrate legacy synthetic.conf entry to synthetic.d if needed
         if not SYNTHETIC_CONF.exists():
-            legacy = Path("/etc/synthetic.conf")
+            legacy = LEGACY_SYNTHETIC_CONF
             try:
                 content = legacy.read_text() if legacy.exists() else ""
             except OSError:
@@ -387,7 +392,7 @@ def _remove_build_link():
             log.warning("  Could not update %s: %s", SYNTHETIC_CONF, e)
 
     # Also clean legacy entry from /etc/synthetic.conf (pre-v1.3.3)
-    legacy_conf = Path("/etc/synthetic.conf")
+    legacy_conf = LEGACY_SYNTHETIC_CONF
     if legacy_conf.exists():
         try:
             content = legacy_conf.read_text()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,6 +61,7 @@ def tmp_data_dir(tmp_path):
     lock_file = data_dir / "start.lock"
     synthetic_conf = tmp_path / "synthetic.d" / "immich-accelerator"
     synthetic_conf.parent.mkdir(parents=True, exist_ok=True)
+    legacy_synthetic = tmp_path / "synthetic.conf"
 
     with patch.multiple(
         "immich_accelerator.__main__",
@@ -72,6 +73,7 @@ def tmp_data_dir(tmp_path):
         # A real install has this file, and two tests wrote to and removed the
         # user's actual /etc/synthetic.d entry.
         SYNTHETIC_CONF=synthetic_conf,
+        LEGACY_SYNTHETIC_CONF=legacy_synthetic,
         # reconcile_ml's "has it been quiet too long" timer. Module state, so a
         # test that leaves it set decides the outcome of the next one; patching
         # it here means every test starts from "no silence recorded yet".

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,30 @@ from unittest.mock import patch
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def no_real_machine_reads(monkeypatch):
+    """Stop tests seeing the accelerator that is running on this machine.
+
+    The suite passed on a laptop that does not run the product and failed
+    eight ways on the Mac that does, which is the worst possible split: the
+    people most likely to run the tests are the ones actually using the thing.
+    Both outside contributors had already started writing "pre-existing
+    failures, unrelated" in their pull requests, and a suite that is red for
+    everyone who runs the product teaches everyone to ignore red.
+
+    Two routes in, both closed here. read_pid("worker") falls back to a global
+    process scan and adopts a live production worker, so "no pid file" tests
+    found one anyway. _ml_ping opens a real HTTP connection to localhost:3003
+    and the real ML service answers, so "ML is down, restart it" tests saw it
+    up. A test that wants either behaviour patches it back explicitly.
+    """
+    import immich_accelerator.__main__ as m
+
+    monkeypatch.setattr(m, "_adopt_live_worker", lambda: None)
+    monkeypatch.setattr(m, "_ml_ping", lambda *a, **k: False)
+    yield
+
+
 @pytest.fixture
 def tmp_data_dir(tmp_path):
     """Point every module-level path at a temp directory.
@@ -35,6 +59,8 @@ def tmp_data_dir(tmp_path):
     log_dir.mkdir()
     config_file = data_dir / "config.json"
     lock_file = data_dir / "start.lock"
+    synthetic_conf = tmp_path / "synthetic.d" / "immich-accelerator"
+    synthetic_conf.parent.mkdir(parents=True, exist_ok=True)
 
     with patch.multiple(
         "immich_accelerator.__main__",
@@ -43,6 +69,9 @@ def tmp_data_dir(tmp_path):
         PID_DIR=pid_dir,
         LOG_DIR=log_dir,
         LOCK_FILE=lock_file,
+        # A real install has this file, and two tests wrote to and removed the
+        # user's actual /etc/synthetic.d entry.
+        SYNTHETIC_CONF=synthetic_conf,
         # reconcile_ml's "has it been quiet too long" timer. Module state, so a
         # test that leaves it set decides the outcome of the next one; patching
         # it here means every test starts from "no silence recorded yet".


### PR DESCRIPTION
The suite passes on a laptop that does not run the product and fails eight ways on the Mac that does. Both outside contributors have started writing "7 pre-existing failures, unrelated" in their pull requests, which is the real cost: a suite that is red for everyone who runs the product teaches everyone to ignore red.

Reported by @pl4za across #129, #130 and #131, and reproduced on the release Mac: 8 failed there against 0 on a laptop.

Three routes into the live machine, all closed:

- `read_pid("worker")` falls back to a global process scan and adopts a running production worker, so every "no pid file" test found one anyway.
- `_ml_ping` opens a real HTTP connection to localhost:3003 and the real ML service answers, so "ML is down, restart it" tests saw it up. That one arrived in 1.10.0.
- `SYNTHETIC_CONF`, and a hardcoded `/etc/synthetic.conf` alongside it, meant two tests read and queued a rewrite of the user's actual system file. Those tests only pass on a Mac where that file is empty.

Same shape as `LOCK_FILE`, `LAUNCH_AGENTS_DIR` and `MANAGED_DOCKER_DIR` before them: a constant derived once at import is invisible to a fixture that patches only what it was derived from.

## Testing

353 passed on the release Mac, which fails 8 on current main. 386 passed on a laptop.