### PR TITLE
Handle a Docker installation whose daemon is not running

### DIFF
--- a/immich_accelerator/__main__.py
+++ b/immich_accelerator/__main__.py
@@ -548,6 +548,40 @@ def find_docker() -> str:
     )
 
 
+def _docker_is_running(docker: str) -> bool:
+    """Report whether this Docker binary can reach a daemon.
+
+    A stopped OrbStack does not always refuse: it can wait for its daemon
+    instead, so readiness has to be judged on the timeout as well as on the
+    exit status.
+    """
+    try:
+        result = subprocess.run([docker, "info"], capture_output=True, timeout=5)
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+    return result.returncode == 0
+
+
+def _find_running_docker() -> str:
+    """find_docker(), restricted to an installation that answers.
+
+    find_docker() only checks that a binary exists, which is what the setup
+    path wants: _ensure_docker_running() starts a stopped daemon. Every other
+    caller reads live Docker state and has a fallback for not having it, so
+    they want a daemon that is already up.
+
+    This validates the same binary find_docker() picked rather than moving on
+    to the next candidate. Falling through to another engine would swap which
+    Immich stack we inspect, which is a surprise, not a recovery.
+    """
+    docker = find_docker()
+    if not _docker_is_running(docker):
+        raise RuntimeError(
+            f"Docker is installed at {docker}, but its daemon is not running"
+        )
+    return docker
+
+
 def _node_major_version(node_path: str) -> int | None:
     """Return the major version integer of a node binary, or None.
 
@@ -644,13 +678,23 @@ def is_valid_version(version: str) -> bool:
 # --- Docker detection ---
 
 
+def _docker_capture(argv: list[str], timeout: int) -> subprocess.CompletedProcess:
+    """Run a docker command for detection, reporting a hang as RuntimeError.
+
+    Every detection call fails the same way: we could not read local Docker
+    state. A daemon that stops between _find_running_docker() and here leaves
+    the CLI waiting, and callers only catch RuntimeError.
+    """
+    try:
+        return subprocess.run(argv, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(f"Docker at {argv[0]} stopped responding") from e
+
+
 def detect_immich(docker: str) -> dict:
     """Detect running Immich instance from Docker."""
-    result = subprocess.run(
-        [docker, "ps", "--format", "{{.Names}}\t{{.Image}}"],
-        capture_output=True,
-        text=True,
-        timeout=10,
+    result = _docker_capture(
+        [docker, "ps", "--format", "{{.Names}}\t{{.Image}}"], 10
     )
     if result.returncode != 0:
         raise RuntimeError(
@@ -676,11 +720,9 @@ def detect_immich(docker: str) -> dict:
 
     # Get version from package.json inside the container
     version = "unknown"
-    version_result = subprocess.run(
+    version_result = _docker_capture(
         [docker, "exec", server_container, "cat", "/usr/src/app/server/package.json"],
-        capture_output=True,
-        text=True,
-        timeout=10,
+        10,
     )
     if version_result.returncode == 0:
         try:
@@ -689,11 +731,8 @@ def detect_immich(docker: str) -> dict:
             pass
 
     if not is_valid_version(version):
-        inspect = subprocess.run(
-            [docker, "inspect", server_container, "--format", "{{.Config.Image}}"],
-            capture_output=True,
-            text=True,
-            timeout=10,
+        inspect = _docker_capture(
+            [docker, "inspect", server_container, "--format", "{{.Config.Image}}"], 10
         )
         if inspect.returncode == 0:
             tag = inspect.stdout.strip().split(":")[-1]
@@ -701,12 +740,7 @@ def detect_immich(docker: str) -> dict:
                 version = tag
 
     # Get env vars
-    env_result = subprocess.run(
-        [docker, "exec", server_container, "env"],
-        capture_output=True,
-        text=True,
-        timeout=10,
-    )
+    env_result = _docker_capture([docker, "exec", server_container, "env"], 10)
     env = {}
     for line in env_result.stdout.strip().split("\n"):
         if "=" in line:
@@ -784,12 +818,7 @@ def detect_immich(docker: str) -> dict:
 
 def _find_exposed_port(docker: str, container_names: list[str], default: str) -> str:
     for name in container_names:
-        result = subprocess.run(
-            [docker, "port", name, default],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
+        result = _docker_capture([docker, "port", name, default], 5)
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout.strip().split(":")[-1]
     return default
@@ -3485,8 +3514,7 @@ def _find_docker_or_install() -> str:
     # Wait for Docker daemon
     docker = os.path.expanduser("~/.orbstack/bin/docker")
     for _ in range(30):
-        r = subprocess.run([docker, "info"], capture_output=True, timeout=5)
-        if r.returncode == 0:
+        if _docker_is_running(docker):
             log.info("  OrbStack ready")
             return docker
         time.sleep(2)
@@ -3497,8 +3525,7 @@ def _find_docker_or_install() -> str:
 
 def _ensure_docker_running(docker: str) -> None:
     """Make sure the Docker daemon is up."""
-    r = subprocess.run([docker, "info"], capture_output=True, timeout=5)
-    if r.returncode == 0:
+    if _docker_is_running(docker):
         return
     # Try starting it
     log.info("Docker not running, starting...")
@@ -3507,8 +3534,7 @@ def _ensure_docker_running(docker: str) -> None:
     else:
         subprocess.run(["open", "-a", "Docker"], timeout=10)
     for _ in range(15):
-        r = subprocess.run([docker, "info"], capture_output=True, timeout=5)
-        if r.returncode == 0:
+        if _docker_is_running(docker):
             return
         time.sleep(2)
     raise RuntimeError("Could not start Docker. Start it manually and re-run setup.")
@@ -3850,7 +3876,7 @@ def _setup_remote(args):
     else:
         # Try local Docker pull
         try:
-            docker = find_docker()
+            docker = _find_running_docker()
             image = f"ghcr.io/immich-app/immich-server:v{version}"
             log.info("Pulling %s...", image)
             subprocess.run([docker, "pull", image], check=True, timeout=300)
@@ -4820,7 +4846,7 @@ def _cmd_start(args):
     # Pre-flight: verify Docker config and auto-update if version changed
     immich = {}
     try:
-        docker = find_docker()
+        docker = _find_running_docker()
         immich = detect_immich(docker)
         if immich["workers_include"] != "api":
             log.error(
@@ -5349,7 +5375,7 @@ def cmd_logs(args):
 
 def cmd_update(_args):
     config = load_config()
-    docker = find_docker()
+    docker = _find_running_docker()
     immich = detect_immich(docker)
 
     current = config.get("version", "?")
@@ -5853,7 +5879,7 @@ def _watch_worker(config: dict) -> str | None:
 
                     # Try local Docker first, fall back to Immich API
                     try:
-                        docker = find_docker()
+                        docker = _find_running_docker()
                         immich = detect_immich(docker)
                         running = immich["version"].lstrip("v")
                     except RuntimeError:
@@ -5875,7 +5901,7 @@ def _watch_worker(config: dict) -> str | None:
                         cmd_stop(None)
                         # Re-extract server — try Docker, fall back to ghcr.io download
                         try:
-                            docker = find_docker()
+                            docker = _find_running_docker()
                             immich = detect_immich(docker)
                             server_dir = extract_immich_server(
                                 docker, immich["container"], running

--- a/immich_accelerator/__main__.py
+++ b/immich_accelerator/__main__.py
@@ -4863,12 +4863,21 @@ def _cmd_start(args):
             config["redis_port"] = immich["redis_port"]
             save_config(config)
     except RuntimeError as e:
-        # No local Docker — typical in split setups. We can't read
-        # IMMICH_MEDIA_LOCATION from the container env, but we CAN
-        # probe the Immich API for the Docker-side path prefix and
-        # compare it to our upload_mount. This is the exact case
-        # issue #19 hit, where a silent "proceeding anyway" let the
-        # worker start with mismatched paths and 404 all thumbnails.
+        # Only a split setup has somewhere else to look. setup --url is the
+        # only thing that writes immich_url, so its absence means Immich is
+        # meant to be in local Docker — and we just failed to read it. There
+        # is nothing left to validate against, so starting the worker would
+        # skip both checks above and feed a stack we never confirmed.
+        if not config.get("immich_url"):
+            log.error("Could not read the local Immich container: %s", e)
+            log.error("Start the Immich Docker stack, then try again.")
+            return
+
+        # Split setup: we can't read IMMICH_MEDIA_LOCATION from the container
+        # env, but we CAN probe the Immich API for the Docker-side path prefix
+        # and compare it to our upload_mount. This is the exact case issue #19
+        # hit, where a silent "proceeding anyway" let the worker start with
+        # mismatched paths and 404 all thumbnails.
         log.info("No local Docker — using API probe to validate path mapping.")
         api_key = config.get("api_key", "")
         upload_mount = config.get("upload_mount", "")

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -2621,6 +2621,10 @@ def _worker_env_for(overrides: dict) -> dict:
         "server_dir": "/srv",
         "node": "/usr/bin/node",
         "ml_dir": "/ml",
+        # find_docker is stubbed to fail below, and only a split install may
+        # start without reading its container. Without this the run stops at
+        # the preflight and never builds the env we came for.
+        "immich_url": "http://immich.example:2283",
     }
     config.update(overrides)
     captured = {}
@@ -2659,6 +2663,74 @@ def _worker_env_for(overrides: dict) -> dict:
         with pytest.raises(RuntimeError):
             m.cmd_start(argparse.Namespace(force=True))
     return captured
+
+
+class TestStartWithoutAValidatedDocker:
+    """cmd_start validates IMMICH_WORKERS_INCLUDE and IMMICH_MEDIA_LOCATION
+    against the running container. When detection fails, both are skipped, and
+    what happens next has to depend on whether anything else can answer.
+    """
+
+    def _run(self, config):
+        import immich_accelerator.__main__ as m
+
+        base = {
+            "db_hostname": "localhost",
+            "db_port": "5432",
+            "db_username": "postgres",
+            "db_password": "pw",
+            "db_name": "immich",
+            "redis_hostname": "localhost",
+            "redis_port": "6379",
+            "ml_port": 3003,
+            "version": "3.0.1",
+            "server_dir": "/srv",
+            "node": "/usr/bin/node",
+        }
+        base.update(config)
+        started = MagicMock()
+
+        with patch.object(m, "load_config", return_value=base), patch.object(
+            m, "save_config"
+        ), patch.object(m, "_kill_stale_processes"), patch.object(
+            m, "find_docker", side_effect=RuntimeError("no docker")
+        ), patch.object(
+            m, "read_pid", return_value=None
+        ), patch.object(
+            m, "find_node", return_value="/usr/bin/node"
+        ), patch.object(
+            m, "_check_node_engines_compat", return_value=(True, "")
+        ), patch.object(
+            m, "_verify_sharp_loads", return_value=(True, "")
+        ), patch.object(
+            m, "_build_link_ok", return_value=True
+        ), patch.object(
+            m, "_preflight_env_health", return_value=True
+        ), patch.object(
+            m, "ensure_media_ready", return_value=True
+        ), patch.object(
+            m, "_find_ml_dir", return_value=None
+        ), patch.object(
+            m, "_start_ml_preferred", return_value=(0, None, False)
+        ), patch.object(
+            m, "kill_pid"
+        ), patch.object(
+            m, "start_service", started
+        ):
+            m.cmd_start(argparse.Namespace(force=True))
+        return started
+
+    def test_a_local_install_does_not_start(self, tmp_data_dir):
+        """No immich_url means Immich is supposed to be in local Docker. We
+        could not read it, so there is nothing left to validate against and
+        the worker would be feeding an unconfirmed stack."""
+        assert not self._run({}).called
+
+    def test_a_split_install_still_starts(self, tmp_data_dir):
+        """A split install is expected to have no local Docker; the API probe
+        below covers the path check."""
+        started = self._run({"immich_url": "http://immich.example:2283"})
+        assert started.called
 
 
 class TestWorkerFreeWatchDoesNotStrandTheInstall:

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -23,6 +23,8 @@ from immich_accelerator.__main__ import (
     read_pid,
     kill_pid,
     detect_immich,
+    _docker_is_running,
+    _find_running_docker,
     _find_exposed_port,
     _read_version,
     _build_link_ok,
@@ -2663,6 +2665,65 @@ def _worker_env_for(overrides: dict) -> dict:
         with pytest.raises(RuntimeError):
             m.cmd_start(argparse.Namespace(force=True))
     return captured
+
+
+class TestDockerLiveness:
+    """find_docker only checks that a binary exists. OrbStack's CLI waits for
+    its daemon instead of refusing, so an installed-but-stopped runtime is
+    found and then never answers.
+    """
+
+    def test_a_hang_is_not_running(self):
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="docker", timeout=5),
+        ):
+            assert _docker_is_running("/usr/local/bin/docker") is False
+
+    def test_a_refusal_is_not_running(self):
+        with patch("subprocess.run", return_value=MagicMock(returncode=1)):
+            assert _docker_is_running("/usr/local/bin/docker") is False
+
+    def test_a_missing_binary_is_not_running(self):
+        with patch("subprocess.run", side_effect=OSError("no such file")):
+            assert _docker_is_running("/usr/local/bin/docker") is False
+
+    def test_an_answering_daemon_is_running(self):
+        with patch("subprocess.run", return_value=MagicMock(returncode=0)):
+            assert _docker_is_running("/usr/local/bin/docker") is True
+
+    def test_discovery_rejects_a_stopped_daemon(self):
+        """The callers of _find_running_docker read live Docker state and all
+        catch RuntimeError. Returning a path that hangs turns that into an
+        uncaught TimeoutExpired several calls later."""
+        with patch(
+            "immich_accelerator.__main__.find_docker",
+            return_value="/usr/local/bin/docker",
+        ), patch(
+            "immich_accelerator.__main__._docker_is_running", return_value=False
+        ):
+            with pytest.raises(RuntimeError, match="daemon is not running"):
+                _find_running_docker()
+
+    def test_discovery_returns_an_answering_daemon(self):
+        with patch(
+            "immich_accelerator.__main__.find_docker",
+            return_value="/usr/local/bin/docker",
+        ), patch(
+            "immich_accelerator.__main__._docker_is_running", return_value=True
+        ):
+            assert _find_running_docker() == "/usr/local/bin/docker"
+
+    def test_detection_reports_a_hang_as_runtime_error(self):
+        """A daemon that stops after discovery leaves the CLI waiting mid
+        detection, and every caller of detect_immich catches RuntimeError only.
+        """
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="docker", timeout=10),
+        ):
+            with pytest.raises(RuntimeError, match="stopped responding"):
+                detect_immich("/usr/local/bin/docker")
 
 
 class TestStartWithoutAValidatedDocker:


### PR DESCRIPTION
## Problem

`find_docker()` returns a path if the binary exists. It does not check whether a
daemon answers. Callers then run `docker` commands under
`subprocess.run(..., timeout=N)`.

Those timeouts exist because a `docker` command can hang. But `subprocess.run`
reports a timeout by raising `TimeoutExpired`, which is not a `RuntimeError`,
and the callers catch `RuntimeError` only. The timeout therefore produces a
traceback instead of the fallback it was added for.

Affected entry points:

- `_cmd_start` (`start`): the `except RuntimeError` at the preflight is the
  intended path for a split setup, and it is not reached.
- `cmd_update` (`update`): no local handler.
- The watch daemon's version probe: same.
- `_ensure_docker_running` and the post-install OrbStack wait loop: both call
  `docker info` with `timeout=5` and no handler, which is the code that exists
  to detect a stopped daemon and start it.

## Measurements

macOS, OrbStack installed and not running. `immich-accelerator start` ended in
an uncaught `subprocess.TimeoutExpired`.

Probing the runtime directly in that state:

| Command | Result |
| --- | --- |
| `docker context ls` | No return after 6 minutes; killed by hand. OrbStack's VM was not started by it. |
| `docker info`, `subprocess.run(timeout=5)` | `TimeoutExpired` at 5.0s |
| `docker ps`, `subprocess.run(timeout=5)` | `TimeoutExpired` at 5.0s |

Repeating the probe later on the same machine, OrbStack still stopped,
`docker info` exited 1 in 0.04s with `failed to connect to the docker API at
unix:///.../docker.sock`. A fast refusal is a non-zero exit, which the current
code already handles. Only the non-returning state crashes, so this is an
intermittent failure rather than a permanent one.

Docker Desktop, colima and Rancher refuse immediately, so this is specific to
the runtime listed first in `find_docker()`.

## Changes

### 1. Fail closed when a local install cannot read its Docker container

`_cmd_start` validates two things against the running container: that Docker is
no longer running microservices, and that `IMMICH_MEDIA_LOCATION` matches
`upload_mount`. When detection raises, both are skipped.

A split setup can skip them, because the API probe below covers the path check.
A local install has no second source of truth, so the worker starts against a
stack that was never confirmed. That is the #19 failure mode without the guard:
a mismatched media location 404s every thumbnail, and a Docker worker still
running microservices conflicts with the native one.

`setup --url` is the only code path that writes `immich_url`, and it has done so
since remote setup was introduced, so its absence identifies a local install.

This path is reachable today with no timeout involved: a local install on a
machine with Docker uninstalled already takes it. It is also what makes the
second commit safe, because liveness checking moves "Docker stopped" from
crashing into that same branch.

### 2. Reject a Docker installation whose daemon is not running

`_docker_is_running()` is the readiness check `_ensure_docker_running()` and the
post-install loop already open-code, with the timeout handled.
`_find_running_docker()` is `find_docker()` plus that check. The five callers
that read live Docker state use it.

It validates the binary `find_docker()` picked rather than trying the next
candidate. Falling through to another engine would change which Immich stack is
inspected.

The setup path is unchanged. It goes through `_find_docker_or_install()` and
`_ensure_docker_running()`, which need a stopped daemon so they can start it.

`detect_immich()` also reports a timeout as `RuntimeError`, covering a daemon
that stops between discovery and detection. Extraction (`docker cp`) is left as
it is: a long copy from a slow disk can exceed its timeout legitimately, and
reporting that as "not responding" would be wrong.

## Known limitation

A config from `setup --url http://localhost:2283` has `immich_url` but still
depends on local Docker. After this change it takes the remote fallback while
its own API, Postgres and Redis are also down. Classifying by URL host would be
a second topology guess, so this change does not do it. Closing that case would
need a DB/Redis connectivity check in the Docker-unavailable branch, which
changes behaviour during a remote outage.

## Testing

`pytest -m "not slow"`: 387 passed, 3 failed. The same 3 fail on unmodified
`main` on this machine. They are the `~/.immich-accelerator` and live ML service
interference noted in the 1.11.0 changelog.

12 tests added. `TestStartWithoutAValidatedDocker::test_a_local_install_does_not_start`
fails on `main` and passes here.

CHANGELOG.md is untouched, matching the merged contributions I looked at. I can
add an entry if you prefer.
