### PR TITLE
1.11.2: contributors, issue templates, and an accurate CONTRIBUTING

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -26,23 +26,20 @@ This project is better than it would have been because of the people below. Than
 
 ## Reports that changed the code
 
-Every issue below is cited in a source comment explaining why some piece of this
-project works the way it does. Finding the problem is most of the work.
+Every issue below is cited in a source comment explaining why some piece of this project works the way it does. Finding the problem is most of the work.
 
-- [@shtefko](https://github.com/shtefko) — split-deployment timeouts, `stop` and `restart` not stopping anything, motion video, Canon RAW ([#74](https://github.com/epheterson/immich-apple-silicon/issues/74), [#80](https://github.com/epheterson/immich-apple-silicon/issues/80), [#81](https://github.com/epheterson/immich-apple-silicon/issues/81), [#95](https://github.com/epheterson/immich-apple-silicon/issues/95), [#99](https://github.com/epheterson/immich-apple-silicon/issues/99))
-- [@jhoogeboom](https://github.com/jhoogeboom) — pg_dump, the ML directory going stale after an upgrade, thumbnails, ML errors ([#19](https://github.com/epheterson/immich-apple-silicon/issues/19), [#20](https://github.com/epheterson/immich-apple-silicon/issues/20), [#24](https://github.com/epheterson/immich-apple-silicon/issues/24), [#29](https://github.com/epheterson/immich-apple-silicon/issues/29))
-- [@flsabourin](https://github.com/flsabourin) — stalled thumbnails, and the ML crash that still pins our mlx version ([#33](https://github.com/epheterson/immich-apple-silicon/issues/33), [#38](https://github.com/epheterson/immich-apple-silicon/issues/38))
-- [@Rustymage](https://github.com/Rustymage) — upload path mapping, and Neural Engine progress reporting ([#61](https://github.com/epheterson/immich-apple-silicon/issues/61), [#68](https://github.com/epheterson/immich-apple-silicon/issues/68))
-- [@KoenM9264](https://github.com/KoenM9264) — the file-descriptor leak that crashed video encoding ([#89](https://github.com/epheterson/immich-apple-silicon/issues/89))
-- [@goldhandconsultancy](https://github.com/goldhandconsultancy) — setup not detecting the upload location ([#62](https://github.com/epheterson/immich-apple-silicon/issues/62))
-- [@xobust](https://github.com/xobust) — support for a separate thumbnail location ([#115](https://github.com/epheterson/immich-apple-silicon/issues/115))
-- [@exkuretrol](https://github.com/exkuretrol) — authenticated Redis ([#56](https://github.com/epheterson/immich-apple-silicon/issues/56))
-- [@pwnmeow](https://github.com/pwnmeow) — UHDR JPEG handling ([#44](https://github.com/epheterson/immich-apple-silicon/issues/44))
-- [@Amoyblack](https://github.com/Amoyblack) — path mapping ([#42](https://github.com/epheterson/immich-apple-silicon/issues/42))
-- [@kg6kvq](https://github.com/kg6kvq) — path changes breaking the server ([#43](https://github.com/epheterson/immich-apple-silicon/issues/43))
+- [@shtefko](https://github.com/shtefko): split-deployment timeouts, `stop` and `restart` not stopping anything, motion video, Canon RAW ([#74](https://github.com/epheterson/immich-apple-silicon/issues/74), [#80](https://github.com/epheterson/immich-apple-silicon/issues/80), [#81](https://github.com/epheterson/immich-apple-silicon/issues/81), [#95](https://github.com/epheterson/immich-apple-silicon/issues/95), [#99](https://github.com/epheterson/immich-apple-silicon/issues/99))
+- [@jhoogeboom](https://github.com/jhoogeboom): pg_dump, the ML directory going stale after an upgrade, thumbnails, ML errors ([#19](https://github.com/epheterson/immich-apple-silicon/issues/19), [#20](https://github.com/epheterson/immich-apple-silicon/issues/20), [#24](https://github.com/epheterson/immich-apple-silicon/issues/24), [#29](https://github.com/epheterson/immich-apple-silicon/issues/29))
+- [@flsabourin](https://github.com/flsabourin): stalled thumbnails, and the ML crash that still pins our mlx version ([#33](https://github.com/epheterson/immich-apple-silicon/issues/33), [#38](https://github.com/epheterson/immich-apple-silicon/issues/38))
+- [@Rustymage](https://github.com/Rustymage): upload path mapping, and Neural Engine progress reporting ([#61](https://github.com/epheterson/immich-apple-silicon/issues/61), [#68](https://github.com/epheterson/immich-apple-silicon/issues/68))
+- [@KoenM9264](https://github.com/KoenM9264): the file-descriptor leak that crashed video encoding ([#89](https://github.com/epheterson/immich-apple-silicon/issues/89))
+- [@goldhandconsultancy](https://github.com/goldhandconsultancy): setup not detecting the upload location ([#62](https://github.com/epheterson/immich-apple-silicon/issues/62))
+- [@xobust](https://github.com/xobust): support for a separate thumbnail location ([#115](https://github.com/epheterson/immich-apple-silicon/issues/115))
+- [@exkuretrol](https://github.com/exkuretrol): authenticated Redis ([#56](https://github.com/epheterson/immich-apple-silicon/issues/56))
+- [@pwnmeow](https://github.com/pwnmeow): UHDR JPEG handling ([#44](https://github.com/epheterson/immich-apple-silicon/issues/44))
+- [@Amoyblack](https://github.com/Amoyblack): path mapping ([#42](https://github.com/epheterson/immich-apple-silicon/issues/42))
+- [@kg6kvq](https://github.com/kg6kvq): path changes breaking the server ([#43](https://github.com/epheterson/immich-apple-silicon/issues/43))
 
 ---
 
-Contributions are welcome, large or small. A bug report with enough detail to
-reproduce is worth as much as a patch. See [CONTRIBUTING.md](CONTRIBUTING.md) to
-get started.
+Contributions are welcome, large or small. A bug report with enough detail to reproduce is worth as much as a patch. See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,27 @@
+# Contributors
+
+This project is better than it would have been because of the people below. Thank you.
+
+### [@lesurJ](https://github.com/lesurJ)
+
+- The whole SigLIP and SigLIP2 catalog running on the native MLX path ([#123](https://github.com/epheterson/immich-apple-silicon/pull/123))
+- Found that most CLIP models were being fed the wrong pixels, and fixed the preprocessing ([#122](https://github.com/epheterson/immich-apple-silicon/pull/122))
+- `--ml-only` mode, so a spare Mac can be a network ML node ([#119](https://github.com/epheterson/immich-apple-silicon/pull/119))
+- Live ML logs ([#121](https://github.com/epheterson/immich-apple-silicon/pull/121)), onnxruntime threading ([#118](https://github.com/epheterson/immich-apple-silicon/pull/118)), and the docs restructure ([#128](https://github.com/epheterson/immich-apple-silicon/pull/128))
+
+### [@pl4za](https://github.com/pl4za)
+
+- Found HEIC decoding blocking the worker's event loop, which was failing thumbnails permanently on NAS libraries ([#125](https://github.com/epheterson/immich-apple-silicon/pull/125))
+- QuickLook fallback for video that ffmpeg's HEVC decoder rejects ([#126](https://github.com/epheterson/immich-apple-silicon/pull/126))
+- Job retries that survive a long outage ([#129](https://github.com/epheterson/immich-apple-silicon/pull/129))
+- Diagnosed a NAS share vanishing mid-session, which became the accelerator handling its own mounts ([#130](https://github.com/epheterson/immich-apple-silicon/pull/130))
+- Dashboard progress fix ([#131](https://github.com/epheterson/immich-apple-silicon/pull/131))
+
+### [@RxChi1d](https://github.com/RxChi1d)
+
+- Found that a Docker install whose daemon is not running crashed the accelerator instead of falling back ([#138](https://github.com/epheterson/immich-apple-silicon/pull/138))
+- Reported the native ML engine holding models after jobs finish, with a fix ([#136](https://github.com/epheterson/immich-apple-silicon/issues/136), [#137](https://github.com/epheterson/immich-apple-silicon/pull/137))
+
+---
+
+Contributions are welcome, large or small. Bug reports with enough detail to reproduce are worth as much as patches. See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,6 +2,8 @@
 
 This project is better than it would have been because of the people below. Thank you.
 
+## Code
+
 ### [@lesurJ](https://github.com/lesurJ)
 
 - The whole SigLIP and SigLIP2 catalog running on the native MLX path ([#123](https://github.com/epheterson/immich-apple-silicon/pull/123))
@@ -22,6 +24,25 @@ This project is better than it would have been because of the people below. Than
 - Found that a Docker install whose daemon is not running crashed the accelerator instead of falling back ([#138](https://github.com/epheterson/immich-apple-silicon/pull/138))
 - Reported the native ML engine holding models after jobs finish, with a fix ([#136](https://github.com/epheterson/immich-apple-silicon/issues/136), [#137](https://github.com/epheterson/immich-apple-silicon/pull/137))
 
+## Reports that changed the code
+
+Every issue below is cited in a source comment explaining why some piece of this
+project works the way it does. Finding the problem is most of the work.
+
+- [@shtefko](https://github.com/shtefko) — split-deployment timeouts, `stop` and `restart` not stopping anything, motion video, Canon RAW ([#74](https://github.com/epheterson/immich-apple-silicon/issues/74), [#80](https://github.com/epheterson/immich-apple-silicon/issues/80), [#81](https://github.com/epheterson/immich-apple-silicon/issues/81), [#95](https://github.com/epheterson/immich-apple-silicon/issues/95), [#99](https://github.com/epheterson/immich-apple-silicon/issues/99))
+- [@jhoogeboom](https://github.com/jhoogeboom) — pg_dump, the ML directory going stale after an upgrade, thumbnails, ML errors ([#19](https://github.com/epheterson/immich-apple-silicon/issues/19), [#20](https://github.com/epheterson/immich-apple-silicon/issues/20), [#24](https://github.com/epheterson/immich-apple-silicon/issues/24), [#29](https://github.com/epheterson/immich-apple-silicon/issues/29))
+- [@flsabourin](https://github.com/flsabourin) — stalled thumbnails, and the ML crash that still pins our mlx version ([#33](https://github.com/epheterson/immich-apple-silicon/issues/33), [#38](https://github.com/epheterson/immich-apple-silicon/issues/38))
+- [@Rustymage](https://github.com/Rustymage) — upload path mapping, and Neural Engine progress reporting ([#61](https://github.com/epheterson/immich-apple-silicon/issues/61), [#68](https://github.com/epheterson/immich-apple-silicon/issues/68))
+- [@KoenM9264](https://github.com/KoenM9264) — the file-descriptor leak that crashed video encoding ([#89](https://github.com/epheterson/immich-apple-silicon/issues/89))
+- [@goldhandconsultancy](https://github.com/goldhandconsultancy) — setup not detecting the upload location ([#62](https://github.com/epheterson/immich-apple-silicon/issues/62))
+- [@xobust](https://github.com/xobust) — support for a separate thumbnail location ([#115](https://github.com/epheterson/immich-apple-silicon/issues/115))
+- [@exkuretrol](https://github.com/exkuretrol) — authenticated Redis ([#56](https://github.com/epheterson/immich-apple-silicon/issues/56))
+- [@pwnmeow](https://github.com/pwnmeow) — UHDR JPEG handling ([#44](https://github.com/epheterson/immich-apple-silicon/issues/44))
+- [@Amoyblack](https://github.com/Amoyblack) — path mapping ([#42](https://github.com/epheterson/immich-apple-silicon/issues/42))
+- [@kg6kvq](https://github.com/kg6kvq) — path changes breaking the server ([#43](https://github.com/epheterson/immich-apple-silicon/issues/43))
+
 ---
 
-Contributions are welcome, large or small. Bug reports with enough detail to reproduce are worth as much as patches. See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.
+Contributions are welcome, large or small. A bug report with enough detail to
+reproduce is worth as much as a patch. See [CONTRIBUTING.md](CONTRIBUTING.md) to
+get started.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Everything past the quick start lives in [`docs/`](docs/):
 | [docs/troubleshooting.md](docs/troubleshooting.md)     | Symptom → cause → fix for common setup and runtime issues                                                                                               |
 | [docs/security.md](docs/security.md)                   | Safety guarantees and every network-facing surface                                                                                                      |
 | [CONTRIBUTING.md](CONTRIBUTING.md)                     | Testing requirements and PR guidelines                                                                                                                  |
+| [CONTRIBUTORS.md](CONTRIBUTORS.md)                     | The people who have made this better                                                                                                                    |
 
 ## Repo layout
 


### PR DESCRIPTION
Docs and repo housekeeping. No code changes.

## The part that mattered

`CONTRIBUTING.md` told machine learning contributors to go to a different repository. The native Swift engine is in this one, under `native-ml/`, which is where every native ML contribution has actually landed, and the Python engine's upstream was named wrong too. That is the single thing a new contributor most needs to get right, and #137 arrived while the file was still saying it. It also asked people to update the changelog, which just makes contributors conflict with each other, when the release PR writes it and credits them.

It now also warns that parts of the test suite use the real data directory, so running it on a Mac that is serving a library can stop that machine's worker. True until that is fixed, and better said than discovered.

## The rest

- `CONTRIBUTORS.md`: people who wrote code, and people whose reports changed the code. The second list is not arbitrary, every issue in it is cited in a source comment explaining why some piece of this works the way it does
- Issue templates asking for the Mac, the versions, whether the library is on a network share, and the logs, which is what nearly every diagnosis here has had to ask for
- `SECURITY.md` with a private disclosure route, since there was no stated way to report one
- A CI badge, and contributor avatars in the README

## Test plan

- [x] 448 tests pass, including the release-hygiene checks on VERSION and the changelog heading
- [x] Every relative link in the touched docs resolves
- [x] Issue template YAML parses