### PR TITLE
Report why local Docker extraction failed

### DIFF
--- a/immich_accelerator/__main__.py
+++ b/immich_accelerator/__main__.py
@@ -3999,9 +3999,14 @@ def _setup_remote(args):
                 subprocess.run(
                     [docker, "rm", container], capture_output=True, timeout=10
                 )
-        except (RuntimeError, subprocess.SubprocessError, FileNotFoundError, OSError):
-            # No local Docker — download directly from ghcr.io
-            log.info("  No local Docker — downloading server from ghcr.io...")
+        except (
+            RuntimeError,
+            subprocess.SubprocessError,
+            FileNotFoundError,
+            OSError,
+        ) as err:
+            log.info("  Local Docker extraction failed (%s)", err)
+            log.info("  Downloading server from ghcr.io instead...")
             try:
                 server_dir = download_immich_server(version)
             except RuntimeError as e:


### PR DESCRIPTION
## Problem

In `_setup_remote`, the extraction fallback reports every failure as
`No local Docker — downloading server from ghcr.io...`. That `except` catches
`RuntimeError`, `SubprocessError`, `FileNotFoundError` and `OSError`, so it is
also reached when:

- `docker pull` fails on registry authentication, an unavailable tag, or the
  network
- `docker create` fails because a container named `immich-extract-<version>` is
  left over from an interrupted run
- `docker cp` fails, for example on a full disk
- the extracted server has no `dist/main.js`

In every one of these, `_find_running_docker()` already succeeded and
`Pulling ghcr.io/immich-app/immich-server:vX.Y.Z...` was already printed. The
next line then says there is no local Docker.

## Change

Report the exception instead:

```
  Local Docker extraction failed (Command '[...docker, pull, ...]' returned non-zero exit status 1.)
  Downloading server from ghcr.io instead...
```

The broad `except` is kept. Falling back to the HTTP downloader is a reasonable
response to all of these.

The exception is bound as `err` rather than `e` because the nested `except
RuntimeError as e` around `download_immich_server` already uses that name.

## Testing

`pytest -m "not slow"`: 403 passed, 2 failed, matching unmodified `main` on this
machine. Log text only, so no test is added.
