### PR TITLE
Settle the server cache before fetching the image

### DIFF
--- a/immich_accelerator/__main__.py
+++ b/immich_accelerator/__main__.py
@@ -3979,6 +3979,15 @@ def _setup_remote(args):
     if args.import_server:
         server_dir = _import_server(args.import_server, version)
     else:
+        # The API already reported the exact version, so the cache can be settled
+        # before deciding how to fetch. Both fetch paths make this same check, but
+        # extract_immich_server only reaches it after `docker pull` has run.
+        bare_version = version.lstrip("v")
+        server_dir = _cached_server_if_current(
+            DATA_DIR / "server" / bare_version, bare_version
+        )
+
+    if not args.import_server and server_dir is None:
         # Try local Docker pull
         try:
             docker = _find_running_docker()

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -2249,6 +2249,48 @@ class TestCachedServerIfCurrent:
             assert m._cached_server_if_current(server_dir, "3.0.1") == server_dir
 
 
+class TestRemoteSetupUsesTheCache:
+    """setup --url learns the exact version from the API before it fetches
+    anything, so a warm cache is knowable up front. Both fetch paths check it,
+    but extract_immich_server only reaches its check after `docker pull` has run.
+    """
+
+    def _run(self, cached):
+        import immich_accelerator.__main__ as m
+
+        args = argparse.Namespace(
+            url="http://immich.example:2283", api_key="k", import_server=None
+        )
+        fetched = MagicMock()
+        with patch("builtins.input", return_value=""), patch(
+            "getpass.getpass", return_value="pw"
+        ), patch.object(
+            m, "_query_immich_api", return_value={"version": "3.0.1"}
+        ), patch.object(
+            m, "_detect_docker_media_prefix", return_value=None
+        ), patch.object(
+            m, "_validate_connectivity", return_value=True
+        ), patch.object(
+            m, "_check_local_tools", return_value=("/usr/bin/node", "/ffmpeg", None)
+        ), patch.object(
+            m, "_cached_server_if_current", return_value=cached
+        ), patch.object(
+            m, "find_docker", side_effect=RuntimeError("no docker")
+        ), patch.object(
+            m, "download_immich_server", fetched
+        ), patch.object(
+            m, "_finalize_config"
+        ):
+            m._setup_remote(args)
+        return fetched
+
+    def test_a_warm_cache_skips_the_fetch(self, tmp_data_dir):
+        assert not self._run(Path("/srv/3.0.1")).called
+
+    def test_a_cold_cache_still_fetches(self, tmp_data_dir):
+        assert self._run(None).called
+
+
 class TestFinalizeBuildData:
     """Stamping is the trust signal, so it must only fire when build-data is
     genuinely complete for the version."""


### PR DESCRIPTION
## Problem

`setup --url` reads the exact Immich version from the API, then acquires the
server files.

Both acquisition paths check the cache first: `extract_immich_server()` and
`download_immich_server()` each call `_cached_server_if_current()` before doing
any work. But `extract_immich_server()` runs after `docker pull` and
`docker create`. A cache hit therefore still costs a registry request and a
container, and the pull can fail or stall before the cache is consulted.

The outcome is already correct. A failed pull reaches the broad `except`, and
`download_immich_server()` returns the cache without network access. Only the
preceding work is unnecessary.

The docs call for re-running `setup --url` in three places: to fix a media-path
mismatch (troubleshooting.md), to promote an ML-only node to a full install
(deployment.md), and to restore the LaunchAgent prompt (usage.md).

## Change

Check the cache with the version the API reported, before choosing how to fetch.
This is the same `_cached_server_if_current()` call both paths make, with the
same build-data and plugin completeness rules, so the set of usable caches is
unchanged.

On a cache miss, acquisition is unchanged: Docker first, ghcr.io as the fallback.

The `--import-server` guard is kept on the new condition, so an import that
produces nothing still cannot fall through to automatic acquisition.

## Testing

`pytest -m "not slow"`: 405 passed, 2 failed. The same 2 fail on unmodified
`main` on this machine, from the live ML service on :3003.

Two tests added, next to `TestCachedServerIfCurrent`.
`TestRemoteSetupUsesTheCache::test_a_warm_cache_skips_the_fetch` fails without
the change.

#145 touches the same function about twenty lines away. The two merge cleanly in
either order, and the combined result passes the same suite.
