### PR TITLE
native-ml: bound what one connection to the ML service can cost

### DIFF
--- a/native-ml/Sources/immich-ml-native/Server.swift
+++ b/native-ml/Sources/immich-ml-native/Server.swift
@@ -5,6 +5,96 @@ import Network
 // Network.framework — replaces FastAPI/uvicorn. Reads Content-Length bodies,
 // one request per connection. A concurrency cap mirrors the Python service's
 // max_concurrent_requests backpressure.
+// Ceilings for one connection. This server answers Immich — the worker on this
+// Mac, and the API server for search text embeddings — but the transport
+// enforced none of that, and every unbounded path below was reachable by
+// anything able to open a TCP connection to the port.
+//
+// 64 KiB of headers is orders of magnitude above Immich's own requests and far
+// below what threatens an 8 GB Mac. 64 MiB of body covers the largest preview
+// Immich sends. The header deadline ends a peer that opens a connection and
+// then says nothing; the connection deadline is generous enough for a first-use
+// model fetch, which legitimately holds a /predict open for minutes.
+private let maxHeaderBytes = 64 * 1024
+private let maxBodyBytes = 64 * 1024 * 1024
+private let headerDeadlineSeconds: TimeInterval = 10
+private let connectionDeadlineSeconds: TimeInterval = 300
+
+// A connection, and the one place that ends one.
+//
+// Every terminal path used to be a bare `return`, or a `cancel()` buried in a
+// send completion. The path taken when the headers never completed and the peer
+// had already gone did neither, so the NWConnection stayed alive holding its
+// descriptor. Measured against this server: inside 1,000 aborted requests it
+// stopped accepting connections at 349 open descriptors, still holding the
+// listening socket. macOS gives the process a 256-descriptor soft limit, and
+// processes serving a library here have been found in the same state at 350-353
+// descriptors, most of them CLOSED — which to anything supervising it looks
+// like a service that is up and answering nothing.
+//
+// What follows bounds that; it does not zero it. 3,000 aborted requests still
+// leave 11-29 sockets in CLOSED state, from a cause I have not found. Normal
+// requests leave none, and connections ended by the deadline below leave none.
+private final class Conn {
+    let nw: NWConnection
+    private let lock = NSLock()
+    private var done = false
+    private var timer: DispatchSourceTimer?
+    private let opened = DispatchTime.now()
+
+    init(_ nw: NWConnection) { self.nw = nw }
+
+    // Armed from the moment the connection is accepted and re-armed rather than
+    // cleared once the request is in hand: a peer that completes its headers and
+    // then stalls must not hold a descriptor any longer than one that never
+    // sends them at all.
+    func arm(_ seconds: TimeInterval) {
+        let t = DispatchSource.makeTimerSource(queue: .global())
+        t.schedule(deadline: .now() + seconds)
+        t.setEventHandler { [weak self] in self?.finish() }
+        // Active before anything else can reach it. finish() can land between
+        // here and the store below — a peer that resets the connection the
+        // moment it is accepted does exactly that — and releasing a dispatch
+        // source that was never activated traps the process, which is the same
+        // way of dying this commit exists to remove.
+        t.activate()
+        lock.lock()
+        let already = done
+        if !already {
+            timer?.cancel()
+            timer = t
+        }
+        lock.unlock()
+        // Finished while this one was being built: end it, and leave nothing
+        // installed on a connection that is already over.
+        if already { t.cancel() }
+    }
+
+    // Idempotent. Whichever of EOF, protocol error, size cap, deadline or a
+    // completed response arrives first is the one that ends the connection; the
+    // rest are no-ops.
+    func finish() {
+        lock.lock()
+        let already = done
+        done = true
+        let t = timer
+        timer = nil
+        lock.unlock()
+        guard !already else { return }
+        t?.cancel()
+        nw.cancel()
+    }
+
+    // What is left of the connection's total budget, so that time already spent
+    // reading the request is not handed back for inference. Measured on the
+    // same clock the timers run on: a wall-clock reading would move when the
+    // system clock is corrected.
+    var remainingBudget: TimeInterval {
+        let spent = Double(DispatchTime.now().uptimeNanoseconds - opened.uptimeNanoseconds) / 1e9
+        return max(0, connectionDeadlineSeconds - spent)
+    }
+}
+
 func startServer(port: UInt16, models: Models, maxConcurrent: Int = 4) {
     let sem = DispatchSemaphore(value: maxConcurrent)
     let listener = try! NWListener(using: .tcp, on: NWEndpoint.Port(rawValue: port)!)
@@ -36,19 +126,52 @@ func startServer(port: UInt16, models: Models, maxConcurrent: Int = 4) {
             break
         }
     }
-    listener.newConnectionHandler = { conn in
-        conn.start(queue: .global())
+    listener.newConnectionHandler = { nwConn in
+        let conn = Conn(nwConn)
+        // A connection that dies on its own still has to release the timer and
+        // mark itself finished, or the deadline fires against a dead peer.
+        nwConn.stateUpdateHandler = { state in
+            switch state {
+            case .failed, .cancelled: conn.finish()
+            default: break
+            }
+        }
+        nwConn.start(queue: .global())
+        conn.arm(headerDeadlineSeconds)
         readRequest(conn, buffer: Data(), models: models, sem: sem)
     }
     listener.start(queue: .global())
 }
 
-private func readRequest(_ conn: NWConnection, buffer: Data, models: Models, sem: DispatchSemaphore) {
-    conn.receive(minimumIncompleteLength: 1, maximumLength: 1 << 20) { chunk, _, done, err in
+private func readRequest(_ conn: Conn, buffer: Data, models: Models, sem: DispatchSemaphore) {
+    conn.nw.receive(minimumIncompleteLength: 1, maximumLength: 1 << 20) { chunk, _, done, err in
         var buf = buffer
         if let chunk = chunk { buf.append(chunk) }
         guard let hdrEnd = buf.range(of: Data("\r\n\r\n".utf8)) else {
-            if err == nil && !done { readRequest(conn, buffer: buf, models: models, sem: sem) }
+            // Cap what an unterminated header block may cost before concluding
+            // it is not a request at all. The receive maximum below is per
+            // callback, so without this the buffer grew without limit.
+            if buf.count > maxHeaderBytes {
+                respond(conn, status: "431 Request Header Fields Too Large",
+                        body: Data(), ctype: "text/plain")
+                return
+            }
+            if err == nil && !done {
+                readRequest(conn, buffer: buf, models: models, sem: sem)
+            } else {
+                // The peer stopped mid-headers. This is where the descriptor
+                // leak was: the old code returned here and left the connection
+                // alive forever.
+                conn.finish()
+            }
+            return
+        }
+        // The cap above only sees a header block that has not ended yet. Without
+        // this one, a terminator arriving in the same callback lets a block
+        // through at the receive maximum instead of at the limit.
+        if hdrEnd.lowerBound > maxHeaderBytes {
+            respond(conn, status: "431 Request Header Fields Too Large",
+                    body: Data(), ctype: "text/plain")
             return
         }
         let head = String(data: buf[..<hdrEnd.lowerBound], encoding: .utf8) ?? ""
@@ -56,12 +179,49 @@ private func readRequest(_ conn: NWConnection, buffer: Data, models: Models, sem
         let reqLine = lines.first ?? ""
         let parts = reqLine.components(separatedBy: " ")
         let method = parts.first ?? "", path = parts.count > 1 ? parts[1] : "/"
-        let clen = lines.first { $0.lowercased().hasPrefix("content-length:") }
-            .flatMap { Int($0.split(separator: ":")[1].trimmingCharacters(in: .whitespaces)) } ?? 0
+
+        // Content-Length, without trusting the header to be well formed. The
+        // previous form indexed `split(separator: ":")[1]`, and split drops
+        // empty subsequences: a bare `Content-Length:` yields one element, so
+        // indexing past it aborted the process. One such request, from anywhere
+        // that could reach the port, killed the service.
+        var clen = 0
+        if let lengthLine = lines.first(where: { $0.lowercased().hasPrefix("content-length:") }) {
+            let raw = lengthLine.dropFirst("content-length:".count)
+                .trimmingCharacters(in: .whitespaces)
+            guard let declared = Int(raw), declared >= 0 else {
+                respond(conn, status: "400 Bad Request", body: Data(), ctype: "text/plain")
+                return
+            }
+            clen = declared
+        }
+        if clen > maxBodyBytes {
+            respond(conn, status: "413 Content Too Large", body: Data(), ctype: "text/plain")
+            return
+        }
+        // Headers are complete and well formed, so the tight header deadline has
+        // done its job. Hand the rest of the connection its own budget now, not
+        // after the body arrives: a legitimate multi-megabyte /predict upload
+        // must not be judged against the deadline meant for a peer that never
+        // finished its request line.
+        conn.arm(conn.remainingBudget)
         let ctype = lines.first { $0.lowercased().hasPrefix("content-type:") } ?? ""
         let body = buf[hdrEnd.upperBound...]
-        if body.count < clen && err == nil && !done {
-            readRequest(conn, buffer: buf, models: models, sem: sem); return
+        // Bound what arrives as well as what was declared: a declared length
+        // under the ceiling can still be overshot within one callback.
+        if body.count > maxBodyBytes {
+            respond(conn, status: "413 Content Too Large", body: Data(), ctype: "text/plain")
+            return
+        }
+        if body.count < clen {
+            if err == nil && !done {
+                readRequest(conn, buffer: buf, models: models, sem: sem)
+            } else {
+                // The peer stopped before delivering what it declared. This used
+                // to fall through and be processed as though it were complete.
+                respond(conn, status: "400 Bad Request", body: Data(), ctype: "text/plain")
+            }
+            return
         }
         // Only /predict is gated by the concurrency cap. /ping and /health must
         // answer even while all slots are blocked on a first-use model download,
@@ -77,18 +237,18 @@ private func readRequest(_ conn: NWConnection, buffer: Data, models: Models, sem
     }
 }
 
-private func respond(_ conn: NWConnection, status: String, body: Data, ctype: String = "application/json") {
+private func respond(_ conn: Conn, status: String, body: Data, ctype: String = "application/json") {
     let head = "HTTP/1.1 \(status)\r\nContent-Type: \(ctype)\r\nContent-Length: \(body.count)\r\nConnection: close\r\n\r\n"
     var out = Data(head.utf8); out.append(body)
-    conn.send(content: out, completion: .contentProcessed { _ in conn.cancel() })
+    conn.nw.send(content: out, completion: .contentProcessed { _ in conn.finish() })
 }
 
-private func respondJSON(_ conn: NWConnection, status: String, object: Any) {
+private func respondJSON(_ conn: Conn, status: String, object: Any) {
     let data = (try? JSONSerialization.data(withJSONObject: object)) ?? Data("{}".utf8)
     respond(conn, status: status, body: data)
 }
 
-private func handle(_ conn: NWConnection, method: String, path: String, ctype: String, body: Data, models: Models) {
+private func handle(_ conn: Conn, method: String, path: String, ctype: String, body: Data, models: Models) {
     switch path {
     case "/":
         respondJSON(conn, status: "200 OK", object: ["message": "Immich ML"])

--- a/scripts/native-ml-preflight.py
+++ b/scripts/native-ml-preflight.py
@@ -39,6 +39,8 @@ import base64
 import json
 import os
 import signal
+import socket
+import struct
 import subprocess
 import sys
 import time
@@ -312,6 +314,191 @@ def check_bind_conflict(
     return None
 
 
+# Ceilings and deadlines enforced by Server.swift. Duplicated here on purpose:
+# this gate drives the binary over a socket and has no way to read them out of
+# it. Keep in sync if they change there.
+HEADER_LIMIT = 64 * 1024
+HEADER_DEADLINE = 10
+BODY_LIMIT = 64 * 1024 * 1024
+
+# A bare `Content-Length:` used to abort the process, so the first of these
+# variants killed the server outright. The rest are the shapes around it that a
+# hand-rolled parser gets wrong: nothing, blanks, text, negative, past Int, and
+# a value that is only separators.
+BAD_LENGTHS = [b"", b"   ", b" abc", b" -1", b" 99999999999999999999999", b"::"]
+
+
+def http_status(raw: bytes) -> str:
+    """The status code of a response, or "" if the peer said nothing usable."""
+    first = raw.split(b"\r\n", 1)[0].decode(errors="replace").split(" ")
+    return first[1] if len(first) > 1 else ""
+
+
+def speak(
+    port: int,
+    request: bytes,
+    half_close: bool = False,
+    timeout: int = 30,
+    chunk: int = 0,
+) -> bytes:
+    """Send one raw request and read the answer to EOF.
+
+    Sends are allowed to fail: the server answers an oversized request as soon
+    as it has seen enough of it, so the rest of the write can land on a socket
+    it has already closed.
+    """
+    s = socket.create_connection(("127.0.0.1", port), timeout=timeout)
+    try:
+        try:
+            if chunk:
+                for i in range(0, len(request), chunk):
+                    s.sendall(request[i : i + chunk])
+                    time.sleep(0.01)
+            else:
+                s.sendall(request)
+            if half_close:
+                s.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+        out = b""
+        while True:
+            try:
+                chunk = s.recv(65536)
+            except OSError:
+                break
+            if not chunk:
+                break
+            out += chunk
+        return out
+    finally:
+        s.close()
+
+
+def abort_connection(port: int, speak_first: bool = True) -> None:
+    """A client that goes away: half a request then a reset, or a reset on a
+    connection it never said anything on. The silent form arrives while the
+    server is still setting the connection up, which is a different race."""
+    s = socket.create_connection(("127.0.0.1", port), timeout=5)
+    try:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0))
+        if speak_first:
+            s.sendall(b"GET /ping HTTP/1.1\r\nHost: x")
+    except OSError:
+        pass
+    finally:
+        s.close()
+
+
+def open_fds(pid: int) -> int | None:
+    """Descriptors the process holds, or None where lsof cannot say."""
+    r = subprocess.run(["lsof", "-p", str(pid)], capture_output=True, text=True)
+    lines = r.stdout.splitlines()
+    return max(0, len(lines) - 1) if lines else None
+
+
+def check_request_bounds(
+    port: int, proc: subprocess.Popen, aborts: int = 300, fd_slack: int = 25
+) -> str | None:
+    """Malformed, oversized and abandoned requests: answered or dropped, never
+    fatal and never accumulating. Returns None on success, else a reason.
+
+    Runs before the model stages because none of it needs a model, and because a
+    build that dies on a malformed header should fail this gate in seconds
+    rather than after a multi-gigabyte first fetch. Everything here is reachable
+    by anything able to open a TCP connection to the port: in a split
+    deployment the listener binds all interfaces, since the API server calls
+    this service for search embeddings.
+    """
+    def problem(what: str, detail: str) -> str:
+        """Name the failure, telling a crash apart from a wrong answer. A trap
+        lands a moment after the connection resets, so the answer — or the
+        absence of one — arrives before the exit status does."""
+        time.sleep(1)
+        if proc.poll() is not None:
+            return f"the service died on {what}"
+        return f"{what} {detail}"
+
+    for bad in BAD_LENGTHS:
+        req = b"GET /ping HTTP/1.1\r\nHost: x\r\nContent-Length:" + bad + b"\r\n\r\n"
+        status = http_status(speak(port, req))
+        if status != "400":
+            return problem(
+                f"Content-Length:{bad.decode()!r}",
+                f"answered {status or 'nothing'}, expected 400",
+            )
+
+    # Headers past the ceiling, in both shapes: one block that never ends (the
+    # receive maximum in Server.swift is per callback, not cumulative, so
+    # without a ceiling this grows for as long as the peer keeps typing), and
+    # one whose terminator arrives together with the oversized block.
+    pad = b"GET /ping HTTP/1.1\r\nX-Pad: " + b"a" * (HEADER_LIMIT + 4096)
+    for ending, shape in ((b"\r\n", "unterminated"), (b"\r\n\r\n", "terminated")):
+        # In 8 KiB writes, so the ceiling has to hold across callbacks rather
+        # than only against one oversized delivery.
+        status = http_status(speak(port, pad + ending, chunk=8192))
+        if status != "431":
+            return problem(
+                f"{len(pad) + len(ending)} bytes of {shape} headers",
+                f"answered {status or 'nothing'}, expected 431",
+            )
+
+    declared = BODY_LIMIT + 1
+    req = f"POST /predict HTTP/1.1\r\nHost: x\r\nContent-Length: {declared}\r\n\r\n".encode()
+    status = http_status(speak(port, req))
+    if status != "413":
+        return problem(
+            f"a declared body of {declared} bytes",
+            f"answered {status or 'nothing'}, expected 413",
+        )
+
+    # Ends before the declared length. This used to be handled as though the
+    # body had arrived complete: /ping answered 200 on five bytes of a hundred.
+    req = b"POST /ping HTTP/1.1\r\nHost: x\r\nContent-Length: 100\r\n\r\nshort"
+    status = http_status(speak(port, req, half_close=True))
+    if status != "400":
+        return problem(
+            "a truncated body", f"answered {status or 'nothing'}, expected 400"
+        )
+
+    # Connect and say nothing: the header deadline has to end it, or a peer
+    # that never speaks holds a descriptor for as long as it likes.
+    waited = HEADER_DEADLINE + 5
+    s = socket.create_connection(("127.0.0.1", port), timeout=waited)
+    try:
+        # A read timeout means the server is still holding the connection, and
+        # is the answer this check exists to catch. Any other error is the peer
+        # going away, which is what should happen.
+        closed = s.recv(1) == b""
+    except TimeoutError:
+        closed = False
+    except OSError:
+        closed = True
+    finally:
+        s.close()
+    if not closed:
+        return problem("a silent client", f"was still connected after {waited}s")
+
+    # Abandoned connections must not cost descriptors. Every terminal path used
+    # to be a bare return, and the one taken when the peer had already gone left
+    # the connection alive holding its descriptor.
+    before = open_fds(proc.pid)
+    for i in range(aborts):
+        abort_connection(port, speak_first=i % 2 == 0)
+    time.sleep(2)
+    after = open_fds(proc.pid)
+    if before is None or after is None:
+        return "lsof could not count this process's descriptors, so the leak check did not run"
+    if after - before > fd_slack:
+        return (
+            f"{aborts} aborted requests left {after - before} descriptors behind "
+            f"({before} -> {after}); this is the leak"
+        )
+
+    if http_status(speak(port, b"GET /ping HTTP/1.1\r\nHost: x\r\n\r\n")) != "200":
+        return problem("the service", "stopped answering /ping after all of this")
+    return None
+
+
 def wait_healthy(base: str, proc: subprocess.Popen, timeout: int) -> None:
     deadline = time.time() + timeout
     while time.time() < deadline:
@@ -479,6 +666,18 @@ def main() -> int:
 
     try:
         wait_healthy(base, proc, args.startup_timeout)
+
+        print(
+            "[preflight] request bounds: malformed, oversized and abandoned "
+            "requests ...",
+            flush=True,
+        )
+        reason = check_request_bounds(args.port, proc)
+        if reason:
+            print(f"[preflight] FAIL — {reason}")
+            died_with_abort("on a malformed or abandoned request")
+            return 1
+        print("[preflight] request bounds: OK")
         image = tiny_jpeg()
         text = "a photo of a cat"
 


### PR DESCRIPTION
## Problem

`Server.swift` has three defects. All of them are reachable by anything that can
open a TCP connection to the ML port, and in a split deployment that is every
host on the LAN: the API server calls this service for search text embeddings,
so the listener binds all interfaces.

**An empty `Content-Length` ends the process.** The value was read as
`$0.split(separator: ":")[1]`. `split` drops empty subsequences, so a bare
`Content-Length:` yields a single element and indexing past it traps.

```
printf 'GET /ping HTTP/1.1\r\nHost: x\r\nContent-Length:\r\n\r\n' | nc HOST PORT
```

Against 1.12.0 that ends the process on the first packet: SIGTRAP, no reply, and
the port refuses the next connection. Nothing authenticates first. The request
line is searched alongside the headers, so a request line beginning the same way
reaches the same code.

**Abandoned connections leak descriptors.** When the header block never
completed and the peer had errored or gone away, the read loop returned without
cancelling, and the `NWConnection` stayed alive holding its descriptor. Against
1.12.0, aborted requests — partial headers, then a reset — took the process from
104 open descriptors to 349 inside the first 1,000, and it stopped accepting
connections there while still holding the listening socket. The soft limit is
256 (`launchctl limit maxfiles`). Processes serving a library on this Mac have
been found in the same state: 350-353 descriptors, 241-245 of them CLOSED, up
and answering nothing.

**Nothing bounds one connection.** There is no read deadline, so a peer that
connects and then says nothing holds its descriptor for as long as it likes.
There is no ceiling on accumulated header or body bytes either: the 1 MiB
receive maximum is per callback, not cumulative.

## Change

This does not attempt general HTTP conformance. The server answers Immich, one
request per connection. What it adds is that no `Content-Length` value can trap
the process, and that a connection's headers, body and lifetime each have a
ceiling.

- `Content-Length` is parsed by trimming the header name instead of indexing a
  split. An empty, blank, non-numeric, negative or overflowing value is a 400.
- More than 64 KiB of headers is a 431, whether or not the block has ended, and
  more than 64 MiB of body is a 413. The body ceiling is checked against bytes
  received as well as against the declared length.
- A body that ends before the declared length is a 400. It used to be handled as
  though the body had arrived: `POST /ping` with `Content-Length: 100` and five
  bytes answered 200.
- Ten seconds to finish the headers, then the remainder of a five-minute
  connection budget. Once the headers parse, the connection gets its own budget,
  so a slow multi-megabyte upload is not judged against the deadline meant for a
  peer that never finished its request line.
- One `Conn` owns the connection and ends it exactly once. Whichever of EOF,
  protocol error, size cap, deadline or a completed response arrives first wins;
  the rest are no-ops. The connection's own state handler ends it as well, so a
  connection that dies on its own still releases its timer.

The ceilings are named constants at the top of the file. On this install,
running Immich 3.1.0, the multipart preambles are a few hundred bytes and the
images Immich sends are a few megabytes. Immich reads the selected file into the
multipart body and has no size limit of its own at that call site, so a
deployment whose previews exceed 64 MiB would now get a 413 where it previously
got a prediction.

Two behavior changes to be aware of. The five-minute budget starts when the
connection is accepted and covers body receipt, the concurrency wait, inference
and the response; when it runs out the socket is cancelled, and queued or
running inference continues. And a request that was accepted before because its
body was short or its length header was unparseable is now a 400.

Not addressed here: duplicate or chunked lengths, exact-length body slicing,
MIME parameter quoting, a configurable bind address, cancellation of queued or
running inference, and monitoring of the process's own descriptor count.

## Testing

MacBook Air M1, 8 GB, macOS 26.3, Immich 3.1.0. Release builds of 1.12.0 and of
this branch, each on a spare port, with the production service untouched.

`scripts/native-ml-preflight.py` gets a stage for this, ahead of the model
stages so a build that dies on a malformed header fails the gate in seconds
rather than after a multi-gigabyte first fetch. It drives the release binary
over a socket, needs no model, and takes 12 seconds.

| Check | 1.12.0 | This branch |
| --- | --- | --- |
| Six malformed `Content-Length` values | dies on the first, SIGTRAP | 400, still serving |
| 68 KiB of headers, no terminator | no answer, connection held | 431 |
| 68 KiB of headers, terminated | 200 | 431 |
| Declared body of 64 MiB + 1 | no answer, waits for the body | 413 |
| `POST /ping`, 5 bytes of a declared 100 | 200 | 400 |
| Client that connects and says nothing | still connected after 15 s | closed at 10.0 s |
| 300 aborted requests | 104 → 189 descriptors | 104 → 108 |

The stage stops at the first failure, so against 1.12.0 only the first row comes
from a stage run. The rest of that column was measured one check at a time
against the same binary, restarting it after the row that kills it. Four runs of
the last row on this branch gave 105, 106, 108 and 109.

The leak is smaller, not gone. Aborted requests still leave sockets in CLOSED
state, they do not come back over five minutes of idle, and a second run leaves
as many again. Normal requests leave the descriptor count unchanged, and
connections that open and say nothing are all released when the header deadline
cancels them, so what remains comes from connections the peer resets.

I built a throwaway instrumented copy of this branch to find out whether those
are connections this code fails to cancel. It counts accepted connections,
first-time `finish()` calls, and each terminal state the connection handler
sees, behind a debug route. That build is not part of this PR.

Sending 3,000 resets to it, with a partial header each time:

```
                accepted  finished  cancelled  failed  |  fd  CLOSED
start                  3         2          2       0  | 105       0
500 normal           504       503        503       0  | 105       0
3,000 aborts        1135      1134       1134     554  | 119      14
after 60s idle      1137      1136       1136     554  | 119      14
```

Two things to read off that. `accepted` rose by 631, not 3,000: the rest were
reset before the listener accepted them and never reached this code, so the
descriptors that remain are 14 out of 631 accepted connections, not out of
3,000 attempts. And `accepted`, `finished` and `cancelled` move together
throughout. Every connection this code accepts calls `finish()` exactly once and
reaches `.cancelled`; none escapes down a path that does not cancel.

So the descriptors that survive belong to connections that were cancelled and
did reach their terminal state. The `Conn` wrapper has let go of them by then,
and I could not find anything left on the Swift side to release. A weak
reference from the state handler and a guard against issuing a receive on an
already-finished connection each left the number unchanged, and an
`NWConnection` does release its state handler when it is cancelled, so this is
not a reference cycle of this code's making.

I am not proposing `forceCancel()` for this. It differs from `cancel()` in
whether the teardown sends RST or negotiates with FIN, and these connections
have already reached `.cancelled` with their sockets in CLOSED state, so the
protocol exchange is over before the descriptor outlives it.

The stage does not cover the five-minute budget. It would have to wait it out.

The whole gate passes on this branch with the stage in place — request bounds,
warmup, 16 concurrent `/predict` calls, mixed clip+vision, bind conflict:

```
$ scripts/native-ml-preflight.py --binary native-ml/.build/release/immich-ml-native \
      --models ViT-B-32__openai
[preflight] PASS — 1 model(s), 16 concurrent real predict calls each, service alive throughout, no abort
```

The route handlers and their successful responses are unchanged.

`Conn` was raced separately: a copy of it, driven with `finish()` and `arm()` on
two queues for 20,000 iterations, trapped inside the first 2,000 on
`BUG IN CLIENT OF LIBDISPATCH: Release of an inactive object` before the timer
source was activated ahead of the store, and survives all 20,000 after.

**Where this runs.** None of the three CI jobs that run pytest can drive this
binary: `lint` and `fresh-install-docker` are Ubuntu, `fresh-install-macos` runs
only `tests/test_fresh_install.py` and never builds `native-ml`, and
`native-ml-build` builds the Swift target on macos-15 but runs nothing. A pytest
integration test would skip in every job. The preflight gate is where
CONTRIBUTING already sends any change to `native-ml`, and it needs a real Mac.

`pytest -v -m "not slow"`: 401 passed, 3 failed, 20 skipped. The same three fail
on unmodified `main`: two need the `ml` submodule, which this checkout does not
have, and `TestReconcileML::test_a_foreign_listener_is_left_alone` fails on the
base commit with everything it touches mocked.

