### PR TITLE
Check the ML port before starting an engine

### DIFF
--- a/immich_accelerator/__main__.py
+++ b/immich_accelerator/__main__.py
@@ -4377,7 +4377,29 @@ def _start_ml_preferred(config: dict):
     if venv is not None:
         attempts.append(("Python venv", venv, False))
 
+    if not attempts:
+        # Said here rather than by the callers: they see only "no pid", which is
+        # also what a refused start returns, and cannot tell the two apart.
+        log.warning("ML service will not start (no native bundle, no venv).")
+        log.warning(
+            "  If you installed via Homebrew, try: brew reinstall immich-accelerator"
+        )
+        return None, None, False
+
+    port = int(config.get("ml_port", 3003))
     for label, (cmd, cwd, senv), is_native in attempts:
+        # Re-checked before every attempt rather than once for the batch. The
+        # native engine exits on a bind conflict, and the fallback below starts
+        # the venv on any RuntimeError without knowing which failure it was, so
+        # the second engine needs its own answer about the port.
+        state = ml_port_state(port)
+        if state != PORT_FREE:
+            log.warning(
+                "Not starting the %s ML engine: port %d is %s.",
+                label, port, "already in use" if state == PORT_OCCUPIED
+                else "in an unknown state (could not inspect it)",
+            )
+            return None, None, False
         log.info("Starting ML service (%s)...", label)
         try:
             pid = start_service("ml", cmd, senv, cwd)
@@ -4428,7 +4450,17 @@ def _ml_verify_or_fallback(config: dict, pid: int, engine: str):
         return pid, engine
     log.warning("  native ML did not become healthy; falling back to venv")
     kill_pid("ml")
-    wait_for_port_free(config.get("ml_port", 3003))
+    if not wait_for_port_free(config.get("ml_port", 3003)):
+        # The return value used to be discarded and the venv started anyway,
+        # into a port the engine we just killed had not let go of. Do not start
+        # a second engine while the port is still occupied; the next cycle can
+        # try again, for as many cycles as the port stays held.
+        log.warning(
+            "  port %s is still held; leaving the restart for the next cycle "
+            "rather than starting a second engine into a bind conflict.",
+            config.get("ml_port", 3003),
+        )
+        return None, None
     venv = _venv_ml_spec(config, os.environ.copy())
     if venv is not None:
         cmd, cwd, senv = venv
@@ -4469,6 +4501,44 @@ def _listener_pid(port: int) -> int | None:
         return None
     first = out.splitlines()[0].strip() if out else ""
     return int(first) if first.isdigit() else None
+
+
+# Three answers, not two. "Cannot tell" blocks a start as firmly as "occupied":
+# what a start must never do is race a process that already holds the port, and
+# an inspection that failed says nothing about whether one does. Reporting a
+# failed inspection as free would put back exactly the behaviour this replaces.
+PORT_FREE = "free"
+PORT_OCCUPIED = "occupied"
+PORT_UNKNOWN = "unknown"
+
+
+def ml_port_state(port: int) -> str:
+    """Whether anything holds this port, or whether we could not find out.
+
+    lsof exits 0 with the pid when something holds the port, and 1 when nothing
+    matches. It also exits 1 on its own errors, so "free" needs a clean stderr
+    as well. Anything else — lsof is missing, it hung, it answered in a shape we
+    do not recognise — is unknown, never "free".
+    """
+    try:
+        result = subprocess.run(
+            ["/usr/sbin/lsof", "-nP", f"-iTCP:{int(port)}", "-sTCP:LISTEN", "-t"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError, ValueError):
+        return PORT_UNKNOWN
+    out = result.stdout.strip()
+    if result.returncode == 0 and out.splitlines() and out.splitlines()[0].strip().isdigit():
+        return PORT_OCCUPIED
+    # Exit 1 is also how lsof reports its own errors, so an empty stdout alone
+    # does not mean "nothing matched". -t selects -w (lsof(8)), which suppresses
+    # the warnings lsof prints for unreadable mounts, so anything left on stderr
+    # is a real error and must not read as free.
+    if result.returncode == 1 and not out and not result.stderr.strip():
+        return PORT_FREE
+    return PORT_UNKNOWN
 
 
 def adopt_live_ml(config: dict) -> int | None:
@@ -4882,10 +4952,7 @@ def _start_without_worker(config: dict, args) -> None:
 
     ml_pid, ml_engine = _start_ml_service(config)
     if not ml_pid:
-        log.warning("ML service will not start (no native bundle, no venv).")
-        log.warning(
-            "  If you installed via Homebrew, try: brew reinstall immich-accelerator"
-        )
+        log.warning("ML service did not start; the reason is above.")
         return
     log.info("  ML service ready (PID %d, %s)", ml_pid, ml_engine)
 
@@ -5322,10 +5389,7 @@ def _cmd_start(args):
             ml_started_here = True
             log.info("  ML service starting (PID %d, %s)", ml_pid, ml_engine)
         else:
-            log.warning("ML service will not start (no native bundle, no venv).")
-            log.warning(
-                "  If you installed via Homebrew, try: brew reinstall immich-accelerator"
-            )
+            log.warning("ML service did not start; the reason is above.")
     elif ml_pid:
         log.info("ML service already running (PID %d)", ml_pid)
     elif not config.get("ml_dir"):
@@ -5596,7 +5660,16 @@ def _watch_without_worker(config: dict) -> str | None:
     signal.signal(signal.SIGTERM, _graceful_stop)
     signal.signal(signal.SIGINT, _graceful_stop)
 
-    if not read_pid("ml"):
+    if not read_pid("ml") and (
+        not _component_enabled("ml", config) or adopt_live_ml(config) is None
+    ):
+        # Adoption first: a pidfile can be missing while the engine it named is
+        # perfectly healthy, and starting a replacement in that state is how the
+        # bind-conflict loop begins. reconcile_ml already knows this; the startup
+        # path did not, so every watcher launch re-created the problem that
+        # reconcile_ml then had to survive. Only when ML is enabled, matching
+        # _watch_worker: with ML off, _start_without_worker is what stops a
+        # leftover engine, and adopting one instead just delays that.
         log.info("Service not running, starting...")
         _start_without_worker(config, argparse.Namespace(force=True))
     else:
@@ -5792,7 +5865,11 @@ def _watch_worker(config: dict) -> str | None:
     # were already up (avoids a double-start race on the dashboard). A missing
     # ML pid only counts when ML is enabled: otherwise every watcher restart
     # would read "ML is down" and bounce a perfectly healthy worker.
-    ml_missing = _component_enabled("ml", config) and not read_pid("ml")
+    ml_missing = (
+        _component_enabled("ml", config)
+        and not read_pid("ml")
+        and adopt_live_ml(config) is None
+    )
     if not read_pid("worker") or ml_missing:
         log.info("Services not running, starting...")
         cmd_start(argparse.Namespace(force=True))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -21,21 +22,28 @@ def no_real_machine_reads(monkeypatch):
     failures, unrelated" in their pull requests, and a suite that is red for
     everyone who runs the product teaches everyone to ignore red.
 
-    Two routes in, both closed here. read_pid("worker") falls back to a global
+    Four routes in, all closed here. read_pid("worker") falls back to a global
     process scan and adopts a live production worker, so "no pid file" tests
     found one anyway. _ml_ping opens a real HTTP connection to localhost:3003
     and the real ML service answers, so "ML is down, restart it" tests saw it
-    up. A test that wants either behaviour patches it back explicitly.
+    up. ml_port_state runs lsof against the configured port and the real ML
+    service is listening on it, so "start the engine" tests were refused a start
+    on the grounds that the machine's own production service was in the way.
+    port_in_use opens a TCP connection to the same port and gets one, so
+    wait_for_port_free never returned true and anything gated on it declined to
+    act. A test that wants any of these behaviours patches it back explicitly.
     """
     import immich_accelerator.__main__ as m
 
     monkeypatch.setattr(m, "_adopt_live_worker", lambda: None)
     monkeypatch.setattr(m, "_ml_ping", lambda *a, **k: False)
+    monkeypatch.setattr(m, "ml_port_state", lambda *a, **k: m.PORT_FREE)
+    monkeypatch.setattr(m, "port_in_use", lambda *a, **k: False)
     yield
 
 
 @pytest.fixture(autouse=True)
-def tmp_data_dir(tmp_path):
+def tmp_data_dir(tmp_path, monkeypatch):
     """Point every module-level path at a temp directory.
 
     Every one of these is bound at import time off the real home, so anything
@@ -81,6 +89,15 @@ def tmp_data_dir(tmp_path):
         # it here means every test starts from "no silence recorded yet".
         _ml_unresponsive_since=None,
     ):
+        # dashboard.py binds its own CONFIG_FILE off the real home, and its
+        # request handlers re-read it, so they answer from the user's live
+        # install. test_api_requeue_no_api_key builds an app with no API key and
+        # asserts a 400: on a Mac whose config.json has one, the handler read
+        # that file, found a key, and returned 200. Green everywhere except on
+        # the machines of the people using the product, again.
+        dashboard = sys.modules.get("immich_accelerator.dashboard")
+        if dashboard is not None:
+            monkeypatch.setattr(dashboard, "CONFIG_FILE", config_file)
         yield {
             "data_dir": data_dir,
             "config_file": config_file,

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -1140,7 +1140,12 @@ class TestWatchMlOnly:
     def test_starts_when_not_already_running(self, tmp_data_dir):
         import immich_accelerator.__main__ as m
 
+        # Adoption runs before concluding ML is absent, so it has to say "not
+        # ours" here: on a machine actually running the accelerator it would
+        # otherwise adopt the live service and there would be nothing to start.
         with patch.object(m, "read_pid", return_value=None), patch.object(
+            m, "adopt_live_ml", return_value=None
+        ), patch.object(
             m, "reconcile_dashboard"
         ), patch.object(m, "_start_without_worker") as start_no_worker, patch(
             "signal.signal"
@@ -3199,9 +3204,9 @@ class TestReconcileML:
 
         with patch.object(m, "read_pid", return_value=None), patch.object(
             m, "_ml_ping", return_value=True
-        ), patch.object(m, "_find_ml_dir", return_value=None), patch.object(
-            m, "_start_ml_service"
-        ) as start, patch.object(
+        ), patch.object(m, "adopt_live_ml", return_value=None), patch.object(
+            m, "_find_ml_dir", return_value=None
+        ), patch.object(m, "_start_ml_service") as start, patch.object(
             m, "log"
         ) as log:
             m.reconcile_ml({})

--- a/tests/test_service_recovery.py
+++ b/tests/test_service_recovery.py
@@ -11,12 +11,18 @@ starting again.
 """
 
 import argparse
+import os
+import socket
 import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 import immich_accelerator.__main__ as m
+
+# Captured at import, before no_real_machine_reads replaces it: the tests below
+# are the ones that want the real thing.
+REAL_ML_PORT_STATE = m.ml_port_state
 
 MOUNT_OUTPUT = """/dev/disk2s4s1 on / (apfs, sealed, local, read-only, journaled)
 devfs on /dev (devfs, local, nobrowse)
@@ -785,3 +791,172 @@ class TestNothingTouchesAHungMountInProcess:
         )
         for banned in ("os.access", "os.stat", "os.listdir", ".exists()", ".is_dir()"):
             assert banned not in src, f"{banned} can hang forever on a stale mount"
+
+
+class TestPortIsAskedBeforeStarting:
+    """A start must not race a process that already holds the port.
+
+    The state to keep out of: a pidfile goes missing while the engine it named
+    is still serving, the supervisor reads that as ML being absent, and starts a
+    replacement that cannot bind. The native engine then exits, and the venv
+    fallback goes into the same port.
+    """
+
+    CFG = {"ml_port": 3003, "ml_dir": "/tmp", "ml_engine": "native"}
+
+    def _specs(self, mod):
+        """Both engines available, so `attempts` is never empty and the port is
+        the only thing that can stop a start."""
+        return patch.object(
+            mod, "_native_ml_spec", lambda cfg, env: (["/usr/bin/true"], "/tmp", env)
+        ), patch.object(
+            mod, "_venv_ml_spec", lambda cfg, env: (["/usr/bin/true"], "/tmp", env)
+        )
+
+    def test_an_occupied_port_stops_the_start(self, tmp_data_dir):
+        native, venv = self._specs(m)
+        with native, venv, patch.object(
+            m, "ml_port_state", return_value=m.PORT_OCCUPIED
+        ), patch.object(m, "start_service") as start, patch.object(m, "log"):
+            pid, engine, _ = m._start_ml_preferred(dict(self.CFG))
+        start.assert_not_called()
+        assert pid is None and engine is None
+
+    def test_a_port_we_cannot_inspect_stops_it_too(self, tmp_data_dir):
+        """Not knowing is not the same as knowing it is free."""
+        native, venv = self._specs(m)
+        with native, venv, patch.object(
+            m, "ml_port_state", return_value=m.PORT_UNKNOWN
+        ), patch.object(m, "start_service") as start, patch.object(m, "log"):
+            pid, _, _ = m._start_ml_preferred(dict(self.CFG))
+        start.assert_not_called()
+        assert pid is None
+
+    def test_a_free_port_still_starts(self, tmp_data_dir):
+        """The gate must not swallow the ordinary case."""
+        native, venv = self._specs(m)
+        with native, venv, patch.object(
+            m, "ml_port_state", return_value=m.PORT_FREE
+        ), patch.object(m, "start_service", return_value=4321), patch.object(m, "log"):
+            pid, engine, is_native = m._start_ml_preferred(dict(self.CFG))
+        assert pid == 4321 and is_native
+
+    def test_the_port_is_asked_again_before_the_fallback(self, tmp_data_dir):
+        """Asked once for the batch, the venv was started immediately after the
+        native engine had just failed to bind the very same port."""
+        seen = []
+
+        def state(port):
+            seen.append(port)
+            return m.PORT_FREE if len(seen) == 1 else m.PORT_OCCUPIED
+
+        native, venv = self._specs(m)
+        with native, venv, patch.object(
+            m, "ml_port_state", side_effect=state
+        ), patch.object(
+            m, "start_service", side_effect=RuntimeError
+        ) as start, patch.object(m, "log"):
+            pid, _, _ = m._start_ml_preferred(dict(self.CFG))
+        assert len(seen) == 2, "the port must be re-checked before the second engine"
+        # Only the native attempt. Counting the state calls alone would pass even
+        # if the second answer were read and ignored.
+        assert start.call_count == 1
+        assert pid is None
+
+
+
+class TestMlPortState:
+    """The classifier itself, against real lsof rather than a stub. lsof exits 1
+    both when nothing matched and when lsof itself failed, so an empty stdout is
+    not on its own an answer."""
+
+    def test_a_real_listener_reads_as_occupied(self):
+        # The only check here that runs the real binary. The accelerator is
+        # macOS-only and hardcodes this path, so on the Linux lint runner there
+        # is nothing to exercise and every port would read as unknown.
+        if not os.access("/usr/sbin/lsof", os.X_OK):
+            pytest.skip("/usr/sbin/lsof not present")
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+            sock.listen(1)
+            port = sock.getsockname()[1]
+            assert REAL_ML_PORT_STATE(port) == m.PORT_OCCUPIED
+        assert REAL_ML_PORT_STATE(port) == m.PORT_FREE
+
+    def test_lsof_that_cannot_run_is_unknown(self):
+        with patch.object(m.subprocess, "run", side_effect=OSError):
+            assert REAL_ML_PORT_STATE(3003) == m.PORT_UNKNOWN
+
+    def test_lsof_reporting_its_own_error_is_not_free(self):
+        """Exit 1 with nothing on stdout, which is also how "no match" looks."""
+        failed = MagicMock(returncode=1, stdout="", stderr="lsof: no pwd entry\n")
+        with patch.object(m.subprocess, "run", return_value=failed):
+            assert REAL_ML_PORT_STATE(3003) == m.PORT_UNKNOWN
+
+
+class TestFallbackHonoursTheWait:
+    def test_a_port_still_held_cancels_the_fallback(self, tmp_data_dir):
+        """wait_for_port_free's answer used to be discarded, and the venv was
+        started into a port the engine just killed had not let go of."""
+        with patch.object(m, "_ml_healthy", return_value=False), patch.object(
+            m, "kill_pid"
+        ), patch.object(m, "wait_for_port_free", return_value=False), patch.object(
+            m, "_venv_ml_spec"
+        ) as venv, patch.object(m, "log"):
+            pid, engine = m._ml_verify_or_fallback(
+                {"ml_port": 3003}, 111, "native Swift"
+            )
+        venv.assert_not_called()
+        assert pid is None and engine is None
+
+    def test_a_released_port_still_falls_back(self, tmp_data_dir):
+        with patch.object(m, "_ml_healthy", return_value=False), patch.object(
+            m, "kill_pid"
+        ), patch.object(m, "wait_for_port_free", return_value=True), patch.object(
+            m, "_venv_ml_spec", return_value=(["/usr/bin/true"], "/tmp", {})
+        ), patch.object(m, "start_service", return_value=222), patch.object(m, "log"):
+            pid, engine = m._ml_verify_or_fallback(
+                {"ml_port": 3003}, 111, "native Swift"
+            )
+        assert pid == 222 and engine == "Python venv"
+
+
+class TestAdoptionRunsBeforeStarting:
+    """Both watcher entry points concluded ML was absent from the pidfile alone,
+    so a launch while the pidfile was missing started a second engine into the
+    port the first one was still serving."""
+
+    def test_watch_worker_adopts_instead_of_starting(self, tmp_data_dir):
+        """The worker loop too: a live worker plus a missing ml.pid used to run
+        a full cmd_start, which restarted the worker as well."""
+        with patch.object(m, "adopt_live_ml", return_value=64933):
+            mocks = drive_watch(
+                {"worker": True, "ml": True}, ready=[True], pids={"worker": 111}
+            )
+        mocks["cmd_start"].assert_not_called()
+
+    def test_watch_without_worker_adopts_instead_of_starting(self, tmp_data_dir):
+        with patch.object(m, "read_pid", return_value=None), patch.object(
+            m, "adopt_live_ml", return_value=64933
+        ), patch.object(m, "reconcile_dashboard"), patch.object(
+            m, "_start_without_worker"
+        ) as start, patch("signal.signal"), patch(
+            "time.sleep", side_effect=KeyboardInterrupt
+        ):
+            m._watch_without_worker({"ml_port": 3003, "ml": True})
+        start.assert_not_called()
+
+    def test_ml_switched_off_is_not_adopted(self, tmp_data_dir):
+        """With ML off, _start_without_worker is what stops a leftover engine.
+        Adopting one instead would leave it running until the next cycle, and
+        report it as ours in the meantime."""
+        with patch.object(m, "read_pid", return_value=None), patch.object(
+            m, "adopt_live_ml", return_value=64933
+        ) as adopt, patch.object(m, "reconcile_dashboard"), patch.object(
+            m, "_start_without_worker"
+        ) as start, patch("signal.signal"), patch(
+            "time.sleep", side_effect=KeyboardInterrupt
+        ):
+            m._watch_without_worker({"ml_port": 3003, "ml": False})
+        adopt.assert_not_called()
+        start.assert_called_once()


### PR DESCRIPTION
## What this changes

Nothing asks whether the ML port is free before starting an engine. `_start_ml_preferred` goes straight to `start_service`, and two watcher startup paths decide ML is absent from `ml.pid` alone. A pidfile can go missing while the process it named is healthy and serving, and in that state the supervisor starts a second engine into a port the first one still holds.

- `_start_ml_preferred` asks `lsof` about the port before each engine, and starts only when `lsof` reports no listener. Every start path goes through it.
- `_watch_worker` and `_watch_without_worker` call `adopt_live_ml` before concluding ML is absent. `reconcile_ml` has done this since 1.11.0.
- `_ml_verify_or_fallback` acts on `wait_for_port_free`'s return value instead of discarding it.

## What I saw

On 1.11.1, a native engine held port 3003 while the accelerator repeatedly started engines into it. Every round produced a bind failure, a venv fallback that also could not bind, and a worker restart. The pattern repeated from 00:24 to 00:26, then again at 00:39, and ended only when I sent SIGTERM by hand at 00:48.

`reconcile_ml` was not the problem. It made the right call, in the same second:

```
00:39:55 WARNING Port 3003 is already served by something this accelerator did not start
                 (Docker's ML container?). Leaving it alone; stop that service, or set a
                 different ml_port, if this Mac should serve ML.
00:39:55 WARNING Worker crashed — restarting...
00:39:57 INFO  Starting ML service (native Swift)...
00:39:59 ERROR ml exited immediately.
00:39:59 ERROR   [native-ml] cannot listen on port 3003: POSIXErrorCode(rawValue: 48): Address already in use
00:39:59 WARNING   native Swift failed to start
00:39:59 INFO  Starting ML service (Python venv)...
00:40:01 INFO    ML service starting (PID 64958, Python venv)
00:40:01 INFO  Starting Immich worker (version 3.1.0)...
```

That is one cycle of `_watch_worker`. `reconcile_components` runs first and `reconcile_ml` refuses to start, which is the warning at 00:39:55. The worker health check runs later in the same iteration and calls `cmd_start(argparse.Namespace(force=True))` (`__main__.py:5985`), which reaches `_start_ml_preferred`, where nothing asks about the port. `reconcile_ml`'s decision is overridden by a path that never consults it. The fd-leak watchdog at `__main__.py:5958` is a second such caller.

The listener was one of ours. It was not answering `/ping`, and `adopt_live_ml` is only reached after a successful ping, so `reconcile_ml` classified it as foreign and stood back. That is the correct conservative call. Nothing reclaimed it, and nothing stopped the other path from racing it. I am not making a claim in this PR about why it stopped answering.

M1 MacBook Air, macOS 26, accelerator 1.11.1, Immich 3.1.0, library on a local disk, native engine, dashboard on.

## What I verified on current main

A process that fails to bind but outlives `start_service`'s two-second liveness check gets its pid written to `ml.pid`. When it dies, the next `read_pid` unlinks the file.

On a spare port with a listener bound and a dead pid written to `ml.pid`, I called `_start_ml_preferred` with both engine specs stubbed and `start_service` recording its calls:

```
main       start_service called 1 time
this PR    start_service called 0 times, and logs the port and its state
```

1.11.0 put `wait_for_port_free` on both restart paths, and both do wait. `reconcile_ml` acts on the answer. `_ml_verify_or_fallback` discards it and starts the venv either way. The startup paths were not in that scope.

## The port check

`ml_port_state` returns occupied, free, or could not be determined. Only "free" permits a start. `lsof` exits 1 both when nothing matched and when `lsof` itself failed, so free means exit 1 with nothing on stdout and nothing on stderr. `-t` already selects `-w`, so the warnings `lsof` prints for unreadable mounts do not reach stderr.

The port is checked again before each engine rather than once for the batch. `_start_ml_preferred` falls back to the venv on any `RuntimeError` from the native start; it cannot tell a bind conflict from any other failure to start, so the second engine needs its own answer.

## The risk this takes

Refusing to start means ML stays down.

The case to weigh is exactly the one above: an engine of ours holding the port with no usable pidfile and not answering `/ping`. `reconcile_ml` only tries adoption after a successful ping, so nothing reclaims it, and every cycle now refuses to start instead. The user sees a warning naming the port each cycle, and `status` reports ML stopped. If it neither starts answering `/ping` nor exits, that does not resolve on its own.

On `main` the same state produces the spawn-and-lose cycle in the log above. I did not try to fix reclaiming here: killing a process on the strength of a command-line match is a bigger decision than this PR should make.

`lsof` failing or timing out has the same outcome for the same reason. `adopt_live_ml` already depends on the same binary, but this PR is what makes a start depend on it.

A refused start and a missing engine both look like "no pid" to the callers, and both used to draw `no native bundle, no venv` and a `brew reinstall` suggestion. That diagnosis now lives in `_start_ml_preferred`, which is where the engine list is known; the callers report that ML did not start and leave the reason to the line above.

## Tests

New: `ml_port_state` against a real listening socket and against an `lsof` that fails or reports its own error; the free, occupied and unknown answers on `_start_ml_preferred`; the re-check before the fallback engine; the fallback declining a held port and still proceeding on a released one; adoption preempting a start on both watcher paths, and not running when ML is switched off.

Three real-machine reads in the shared fixtures are closed, which is what makes the suite green on a Mac that is running the accelerator:

- `ml_port_state` and `port_in_use` answer for the production service, so tests that start an engine were refused a start by that machine's own ML. Four `TestStartMlService` tests fail without these two stubs.
- `dashboard.py` binds its own `CONFIG_FILE` off the real home, which `tmp_data_dir` did not patch. `test_api_requeue_no_api_key` builds an app with no API key and asserts a 400; on a Mac whose `config.json` has one, the handler re-read that file, found a key, and returned 200. That one is independent of everything else here and can come out if you would rather have it on its own.

`TestReconcileML::test_a_foreign_listener_is_left_alone` also had to patch `adopt_live_ml`. It fails on current `main` on a Mac running the accelerator: the real engine on 3003 is adopted, so the foreign-listener warning never fires.

`pytest -m "not slow"` on an M1 MacBook Air running the accelerator, with the `ml/` submodule checked out: 449 passed, 20 skipped, 11 deselected, 0 failed. Without the submodule, `TestDashboardDependenciesAreAvailable` fails with `FileNotFoundError` on `ml/requirements.txt`, on this branch and on `main` alike — it reads that file directly and `ml` is a gitlink, so a fresh worktree leaves it empty.

## Checklist

- [x] Ran `pytest -v -m "not slow"` locally — all tests pass
- [x] Tested on a real Mac with the accelerator running — full suite, and the port-occupied reproduction above on a spare port
- [x] No unrelated changes bundled in — one exception, flagged above: the `dashboard.py` fixture line is a separate test-isolation fix and can be dropped.
