### PR TITLE
Signal a service's process group only when the group is ours

### DIFF
--- a/immich_accelerator/__main__.py
+++ b/immich_accelerator/__main__.py
@@ -1878,18 +1878,38 @@ def _kill_all_worker_processes():
             pass
 
 
+def _signal_service(pid: int, sig: int) -> None:
+    """Signal one tracked service, by group only where the group is ours.
+
+    Services have children that must go with them: the worker runs several
+    processes and spawns ffmpeg and exiftool, and a uvicorn engine can fork
+    workers. start_service and start_dashboard pass start_new_session, so
+    everything this supervisor spawns is a session leader, and a session
+    leader's process group can only be joined by its own descendants.
+
+    A pid can also be one we adopted rather than spawned — read_pid falls back
+    to a process scan for the worker, adopt_live_ml and start_dashboard adopt a
+    live listener. Session leadership is what separates the two: a process
+    started from a shell leads its job's process group but not the session, and
+    that group is not ours to signal.
+    """
+    try:
+        if os.getsid(pid) == pid:
+            os.killpg(pid, sig)
+            return
+    except OSError:
+        pass
+    try:
+        os.kill(pid, sig)
+    except OSError:
+        pass
+
+
 def kill_pid(name: str) -> bool:
     pid = read_pid(name)
     if pid is None:
         return False
-    try:
-        pgid = os.getpgid(pid)
-        os.killpg(pgid, signal.SIGTERM)
-    except OSError:
-        try:
-            os.kill(pid, signal.SIGTERM)
-        except OSError:
-            pass
+    _signal_service(pid, signal.SIGTERM)
 
     # Also kill any orphaned immich processes not in the same group
     if name == "worker":
@@ -1903,14 +1923,7 @@ def kill_pid(name: str) -> bool:
         except OSError:
             break
     else:
-        try:
-            pgid = os.getpgid(pid)
-            os.killpg(pgid, signal.SIGKILL)
-        except OSError:
-            try:
-                os.kill(pid, signal.SIGKILL)
-            except OSError:
-                pass
+        _signal_service(pid, signal.SIGKILL)
 
     (PID_DIR / f"{name}.pid").unlink(missing_ok=True)
     return True
@@ -4312,7 +4325,14 @@ def _venv_ml_spec(config: dict, env: dict):
         # it into ml.log), which is where uvicorn's access log and any print()
         # output live. Without this, `logs ml` sits blank and then dumps a stale
         # chunk instead of streaming in real time.
-        env = dict(env, PYTHONUNBUFFERED="1")
+        # WEB_CONCURRENCY is inherited from whatever launched the supervisor,
+        # and uvicorn's Config reads it when workers is None, which is how
+        # src.main calls uvicorn.run. A value above one forks that many copies of
+        # the ML service, each loading its own multi-gigabyte model, on a Mac
+        # chosen for this work precisely because memory is the scarce resource.
+        # It also leaves several processes on the port under a master that
+        # ml.pid does not name, and nothing here is written to expect that.
+        env = dict(env, PYTHONUNBUFFERED="1", WEB_CONCURRENCY="1")
         return [str(ml_python), "-m", "src.main"], str(ml_dir), env
     return None
 
@@ -5460,13 +5480,7 @@ def stop_all_fast() -> None:
         if not pid:
             continue
         pids[name] = pid
-        try:
-            os.killpg(os.getpgid(pid), signal.SIGTERM)
-        except OSError:
-            try:
-                os.kill(pid, signal.SIGTERM)
-            except OSError:
-                pass
+        _signal_service(pid, signal.SIGTERM)
     _kill_all_worker_processes()  # sweep orphaned immich procs too
 
     # Short, PARALLEL wait (not 5s-per-service) so we stay well under launchd's
@@ -5475,15 +5489,9 @@ def stop_all_fast() -> None:
         if all(not alive(p) for p in pids.values()):
             break
         time.sleep(0.1)
-    for name, pid in pids.items():
+    for pid in pids.values():
         if alive(pid):
-            try:
-                os.killpg(os.getpgid(pid), signal.SIGKILL)
-            except OSError:
-                try:
-                    os.kill(pid, signal.SIGKILL)
-                except OSError:
-                    pass
+            _signal_service(pid, signal.SIGKILL)
     for name in pids:
         (PID_DIR / f"{name}.pid").unlink(missing_ok=True)
     if pids:

--- a/immich_accelerator/__main__.py
+++ b/immich_accelerator/__main__.py
@@ -4377,7 +4377,29 @@ def _start_ml_preferred(config: dict):
     if venv is not None:
         attempts.append(("Python venv", venv, False))
 
+    if not attempts:
+        # Said here rather than by the callers: they see only "no pid", which is
+        # also what a refused start returns, and cannot tell the two apart.
+        log.warning("ML service will not start (no native bundle, no venv).")
+        log.warning(
+            "  If you installed via Homebrew, try: brew reinstall immich-accelerator"
+        )
+        return None, None, False
+
+    port = int(config.get("ml_port", 3003))
     for label, (cmd, cwd, senv), is_native in attempts:
+        # Re-checked before every attempt rather than once for the batch. The
+        # native engine exits on a bind conflict, and the fallback below starts
+        # the venv on any RuntimeError without knowing which failure it was, so
+        # the second engine needs its own answer about the port.
+        state = ml_port_state(port)
+        if state != PORT_FREE:
+            log.warning(
+                "Not starting the %s ML engine: port %d is %s.",
+                label, port, "already in use" if state == PORT_OCCUPIED
+                else "in an unknown state (could not inspect it)",
+            )
+            return None, None, False
         log.info("Starting ML service (%s)...", label)
         try:
             pid = start_service("ml", cmd, senv, cwd)
@@ -4428,7 +4450,17 @@ def _ml_verify_or_fallback(config: dict, pid: int, engine: str):
         return pid, engine
     log.warning("  native ML did not become healthy; falling back to venv")
     kill_pid("ml")
-    wait_for_port_free(config.get("ml_port", 3003))
+    if not wait_for_port_free(config.get("ml_port", 3003)):
+        # The return value used to be discarded and the venv started anyway,
+        # into a port the engine we just killed had not let go of. Do not start
+        # a second engine while the port is still occupied; the next cycle can
+        # try again, for as many cycles as the port stays held.
+        log.warning(
+            "  port %s is still held; leaving the restart for the next cycle "
+            "rather than starting a second engine into a bind conflict.",
+            config.get("ml_port", 3003),
+        )
+        return None, None
     venv = _venv_ml_spec(config, os.environ.copy())
     if venv is not None:
         cmd, cwd, senv = venv
@@ -4469,6 +4501,44 @@ def _listener_pid(port: int) -> int | None:
         return None
     first = out.splitlines()[0].strip() if out else ""
     return int(first) if first.isdigit() else None
+
+
+# Three answers, not two. "Cannot tell" blocks a start as firmly as "occupied":
+# what a start must never do is race a process that already holds the port, and
+# an inspection that failed says nothing about whether one does. Reporting a
+# failed inspection as free would put back exactly the behaviour this replaces.
+PORT_FREE = "free"
+PORT_OCCUPIED = "occupied"
+PORT_UNKNOWN = "unknown"
+
+
+def ml_port_state(port: int) -> str:
+    """Whether anything holds this port, or whether we could not find out.
+
+    lsof exits 0 with the pid when something holds the port, and 1 when nothing
+    matches. It also exits 1 on its own errors, so "free" needs a clean stderr
+    as well. Anything else — lsof is missing, it hung, it answered in a shape we
+    do not recognise — is unknown, never "free".
+    """
+    try:
+        result = subprocess.run(
+            ["/usr/sbin/lsof", "-nP", f"-iTCP:{int(port)}", "-sTCP:LISTEN", "-t"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError, ValueError):
+        return PORT_UNKNOWN
+    out = result.stdout.strip()
+    if result.returncode == 0 and out.splitlines() and out.splitlines()[0].strip().isdigit():
+        return PORT_OCCUPIED
+    # Exit 1 is also how lsof reports its own errors, so an empty stdout alone
+    # does not mean "nothing matched". -t selects -w (lsof(8)), which suppresses
+    # the warnings lsof prints for unreadable mounts, so anything left on stderr
+    # is a real error and must not read as free.
+    if result.returncode == 1 and not out and not result.stderr.strip():
+        return PORT_FREE
+    return PORT_UNKNOWN
 
 
 def adopt_live_ml(config: dict) -> int | None:
@@ -4882,10 +4952,7 @@ def _start_without_worker(config: dict, args) -> None:
 
     ml_pid, ml_engine = _start_ml_service(config)
     if not ml_pid:
-        log.warning("ML service will not start (no native bundle, no venv).")
-        log.warning(
-            "  If you installed via Homebrew, try: brew reinstall immich-accelerator"
-        )
+        log.warning("ML service did not start; the reason is above.")
         return
     log.info("  ML service ready (PID %d, %s)", ml_pid, ml_engine)
 
@@ -5322,10 +5389,7 @@ def _cmd_start(args):
             ml_started_here = True
             log.info("  ML service starting (PID %d, %s)", ml_pid, ml_engine)
         else:
-            log.warning("ML service will not start (no native bundle, no venv).")
-            log.warning(
-                "  If you installed via Homebrew, try: brew reinstall immich-accelerator"
-            )
+            log.warning("ML service did not start; the reason is above.")
     elif ml_pid:
         log.info("ML service already running (PID %d)", ml_pid)
     elif not config.get("ml_dir"):
@@ -5596,7 +5660,16 @@ def _watch_without_worker(config: dict) -> str | None:
     signal.signal(signal.SIGTERM, _graceful_stop)
     signal.signal(signal.SIGINT, _graceful_stop)
 
-    if not read_pid("ml"):
+    if not read_pid("ml") and (
+        not _component_enabled("ml", config) or adopt_live_ml(config) is None
+    ):
+        # Adoption first: a pidfile can be missing while the engine it named is
+        # perfectly healthy, and starting a replacement in that state is how the
+        # bind-conflict loop begins. reconcile_ml already knows this; the startup
+        # path did not, so every watcher launch re-created the problem that
+        # reconcile_ml then had to survive. Only when ML is enabled, matching
+        # _watch_worker: with ML off, _start_without_worker is what stops a
+        # leftover engine, and adopting one instead just delays that.
         log.info("Service not running, starting...")
         _start_without_worker(config, argparse.Namespace(force=True))
     else:
@@ -5792,7 +5865,11 @@ def _watch_worker(config: dict) -> str | None:
     # were already up (avoids a double-start race on the dashboard). A missing
     # ML pid only counts when ML is enabled: otherwise every watcher restart
     # would read "ML is down" and bounce a perfectly healthy worker.
-    ml_missing = _component_enabled("ml", config) and not read_pid("ml")
+    ml_missing = (
+        _component_enabled("ml", config)
+        and not read_pid("ml")
+        and adopt_live_ml(config) is None
+    )
     if not read_pid("worker") or ml_missing:
         log.info("Services not running, starting...")
         cmd_start(argparse.Namespace(force=True))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -21,21 +22,28 @@ def no_real_machine_reads(monkeypatch):
     failures, unrelated" in their pull requests, and a suite that is red for
     everyone who runs the product teaches everyone to ignore red.
 
-    Two routes in, both closed here. read_pid("worker") falls back to a global
+    Four routes in, all closed here. read_pid("worker") falls back to a global
     process scan and adopts a live production worker, so "no pid file" tests
     found one anyway. _ml_ping opens a real HTTP connection to localhost:3003
     and the real ML service answers, so "ML is down, restart it" tests saw it
-    up. A test that wants either behaviour patches it back explicitly.
+    up. ml_port_state runs lsof against the configured port and the real ML
+    service is listening on it, so "start the engine" tests were refused a start
+    on the grounds that the machine's own production service was in the way.
+    port_in_use opens a TCP connection to the same port and gets one, so
+    wait_for_port_free never returned true and anything gated on it declined to
+    act. A test that wants any of these behaviours patches it back explicitly.
     """
     import immich_accelerator.__main__ as m
 
     monkeypatch.setattr(m, "_adopt_live_worker", lambda: None)
     monkeypatch.setattr(m, "_ml_ping", lambda *a, **k: False)
+    monkeypatch.setattr(m, "ml_port_state", lambda *a, **k: m.PORT_FREE)
+    monkeypatch.setattr(m, "port_in_use", lambda *a, **k: False)
     yield
 
 
 @pytest.fixture(autouse=True)
-def tmp_data_dir(tmp_path):
+def tmp_data_dir(tmp_path, monkeypatch):
     """Point every module-level path at a temp directory.
 
     Every one of these is bound at import time off the real home, so anything
@@ -81,6 +89,15 @@ def tmp_data_dir(tmp_path):
         # it here means every test starts from "no silence recorded yet".
         _ml_unresponsive_since=None,
     ):
+        # dashboard.py binds its own CONFIG_FILE off the real home, and its
+        # request handlers re-read it, so they answer from the user's live
+        # install. test_api_requeue_no_api_key builds an app with no API key and
+        # asserts a 400: on a Mac whose config.json has one, the handler read
+        # that file, found a key, and returned 200. Green everywhere except on
+        # the machines of the people using the product, again.
+        dashboard = sys.modules.get("immich_accelerator.dashboard")
+        if dashboard is not None:
+            monkeypatch.setattr(dashboard, "CONFIG_FILE", config_file)
         yield {
             "data_dir": data_dir,
             "config_file": config_file,

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -1140,7 +1140,12 @@ class TestWatchMlOnly:
     def test_starts_when_not_already_running(self, tmp_data_dir):
         import immich_accelerator.__main__ as m
 
+        # Adoption runs before concluding ML is absent, so it has to say "not
+        # ours" here: on a machine actually running the accelerator it would
+        # otherwise adopt the live service and there would be nothing to start.
         with patch.object(m, "read_pid", return_value=None), patch.object(
+            m, "adopt_live_ml", return_value=None
+        ), patch.object(
             m, "reconcile_dashboard"
         ), patch.object(m, "_start_without_worker") as start_no_worker, patch(
             "signal.signal"
@@ -3199,9 +3204,9 @@ class TestReconcileML:
 
         with patch.object(m, "read_pid", return_value=None), patch.object(
             m, "_ml_ping", return_value=True
-        ), patch.object(m, "_find_ml_dir", return_value=None), patch.object(
-            m, "_start_ml_service"
-        ) as start, patch.object(
+        ), patch.object(m, "adopt_live_ml", return_value=None), patch.object(
+            m, "_find_ml_dir", return_value=None
+        ), patch.object(m, "_start_ml_service") as start, patch.object(
             m, "log"
         ) as log:
             m.reconcile_ml({})

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -358,7 +358,7 @@ class TestPidManagement:
         current_pid = os.getpid()
         with patch(
             "immich_accelerator.__main__.read_pid", return_value=current_pid
-        ), patch("os.getpgid", return_value=current_pid), patch(
+        ), patch("os.getsid", return_value=current_pid), patch(
             "os.killpg"
         ) as mock_killpg, patch(
             "os.kill", side_effect=OSError
@@ -2057,14 +2057,21 @@ class TestStopAllFast:
         pids = {"worker": 111, "ml": 222, "dashboard": 333}
         sent = []
 
+        by_group = []
+
         def fake_kill(pid, sig):
             if sig == 0:
                 raise OSError()  # report dead so the wait loop exits immediately
+            sent.append((pid, sig))
+
+        def fake_killpg(pgid, sig):
+            by_group.append(pgid)
+            sent.append((pgid, sig))
 
         with patch(
             "immich_accelerator.__main__.read_pid", side_effect=lambda n: pids.get(n)
-        ), patch("os.getpgid", side_effect=lambda pid: pid), patch(
-            "os.killpg", side_effect=lambda pgid, sig: sent.append((pgid, sig))
+        ), patch("os.getsid", side_effect=lambda pid: pid), patch(
+            "os.killpg", side_effect=fake_killpg
         ), patch(
             "os.kill", side_effect=fake_kill
         ), patch(
@@ -2072,8 +2079,40 @@ class TestStopAllFast:
         ):
             stop_all_fast()
 
-        termed = {pgid for pgid, sig in sent if sig == signal.SIGTERM}
+        termed = {pid for pid, sig in sent if sig == signal.SIGTERM}
         assert termed == {111, 222, 333}  # all signalled before any wait
+        # getsid is the identity here, so all three lead their own session,
+        # which is what start_new_session gives everything we spawn. Checked on
+        # a live install: worker, ml and dashboard all satisfy getsid(pid)==pid.
+        assert sorted(by_group) == [111, 222, 333]
+
+    def test_a_service_inside_another_group_is_signalled_alone(self):
+        """An adopted pid need not lead its group. Signalling that group would
+        reach processes this supervisor never started."""
+        from immich_accelerator.__main__ import stop_all_fast
+
+        by_group = []
+        killed = []
+
+        def fake_kill(pid, sig):
+            if sig == 0:
+                raise OSError()
+            killed.append(pid)
+
+        with patch(
+            "immich_accelerator.__main__.read_pid",
+            side_effect=lambda n: {"ml": 222}.get(n),
+        ), patch("os.getsid", return_value=900), patch(
+            "os.killpg", side_effect=lambda pgid, sig: by_group.append(pgid)
+        ), patch(
+            "os.kill", side_effect=fake_kill
+        ), patch(
+            "immich_accelerator.__main__._kill_all_worker_processes"
+        ):
+            stop_all_fast()
+
+        assert by_group == []
+        assert killed == [222]
 
 
 class TestBuildHasCorePlugin:

--- a/tests/test_service_recovery.py
+++ b/tests/test_service_recovery.py
@@ -11,12 +11,18 @@ starting again.
 """
 
 import argparse
+import os
+import socket
 import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 import immich_accelerator.__main__ as m
+
+# Captured at import, before no_real_machine_reads replaces it: the tests below
+# are the ones that want the real thing.
+REAL_ML_PORT_STATE = m.ml_port_state
 
 MOUNT_OUTPUT = """/dev/disk2s4s1 on / (apfs, sealed, local, read-only, journaled)
 devfs on /dev (devfs, local, nobrowse)
@@ -785,3 +791,172 @@ class TestNothingTouchesAHungMountInProcess:
         )
         for banned in ("os.access", "os.stat", "os.listdir", ".exists()", ".is_dir()"):
             assert banned not in src, f"{banned} can hang forever on a stale mount"
+
+
+class TestPortIsAskedBeforeStarting:
+    """A start must not race a process that already holds the port.
+
+    The state to keep out of: a pidfile goes missing while the engine it named
+    is still serving, the supervisor reads that as ML being absent, and starts a
+    replacement that cannot bind. The native engine then exits, and the venv
+    fallback goes into the same port.
+    """
+
+    CFG = {"ml_port": 3003, "ml_dir": "/tmp", "ml_engine": "native"}
+
+    def _specs(self, mod):
+        """Both engines available, so `attempts` is never empty and the port is
+        the only thing that can stop a start."""
+        return patch.object(
+            mod, "_native_ml_spec", lambda cfg, env: (["/usr/bin/true"], "/tmp", env)
+        ), patch.object(
+            mod, "_venv_ml_spec", lambda cfg, env: (["/usr/bin/true"], "/tmp", env)
+        )
+
+    def test_an_occupied_port_stops_the_start(self, tmp_data_dir):
+        native, venv = self._specs(m)
+        with native, venv, patch.object(
+            m, "ml_port_state", return_value=m.PORT_OCCUPIED
+        ), patch.object(m, "start_service") as start, patch.object(m, "log"):
+            pid, engine, _ = m._start_ml_preferred(dict(self.CFG))
+        start.assert_not_called()
+        assert pid is None and engine is None
+
+    def test_a_port_we_cannot_inspect_stops_it_too(self, tmp_data_dir):
+        """Not knowing is not the same as knowing it is free."""
+        native, venv = self._specs(m)
+        with native, venv, patch.object(
+            m, "ml_port_state", return_value=m.PORT_UNKNOWN
+        ), patch.object(m, "start_service") as start, patch.object(m, "log"):
+            pid, _, _ = m._start_ml_preferred(dict(self.CFG))
+        start.assert_not_called()
+        assert pid is None
+
+    def test_a_free_port_still_starts(self, tmp_data_dir):
+        """The gate must not swallow the ordinary case."""
+        native, venv = self._specs(m)
+        with native, venv, patch.object(
+            m, "ml_port_state", return_value=m.PORT_FREE
+        ), patch.object(m, "start_service", return_value=4321), patch.object(m, "log"):
+            pid, engine, is_native = m._start_ml_preferred(dict(self.CFG))
+        assert pid == 4321 and is_native
+
+    def test_the_port_is_asked_again_before_the_fallback(self, tmp_data_dir):
+        """Asked once for the batch, the venv was started immediately after the
+        native engine had just failed to bind the very same port."""
+        seen = []
+
+        def state(port):
+            seen.append(port)
+            return m.PORT_FREE if len(seen) == 1 else m.PORT_OCCUPIED
+
+        native, venv = self._specs(m)
+        with native, venv, patch.object(
+            m, "ml_port_state", side_effect=state
+        ), patch.object(
+            m, "start_service", side_effect=RuntimeError
+        ) as start, patch.object(m, "log"):
+            pid, _, _ = m._start_ml_preferred(dict(self.CFG))
+        assert len(seen) == 2, "the port must be re-checked before the second engine"
+        # Only the native attempt. Counting the state calls alone would pass even
+        # if the second answer were read and ignored.
+        assert start.call_count == 1
+        assert pid is None
+
+
+
+class TestMlPortState:
+    """The classifier itself, against real lsof rather than a stub. lsof exits 1
+    both when nothing matched and when lsof itself failed, so an empty stdout is
+    not on its own an answer."""
+
+    def test_a_real_listener_reads_as_occupied(self):
+        # The only check here that runs the real binary. The accelerator is
+        # macOS-only and hardcodes this path, so on the Linux lint runner there
+        # is nothing to exercise and every port would read as unknown.
+        if not os.access("/usr/sbin/lsof", os.X_OK):
+            pytest.skip("/usr/sbin/lsof not present")
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+            sock.listen(1)
+            port = sock.getsockname()[1]
+            assert REAL_ML_PORT_STATE(port) == m.PORT_OCCUPIED
+        assert REAL_ML_PORT_STATE(port) == m.PORT_FREE
+
+    def test_lsof_that_cannot_run_is_unknown(self):
+        with patch.object(m.subprocess, "run", side_effect=OSError):
+            assert REAL_ML_PORT_STATE(3003) == m.PORT_UNKNOWN
+
+    def test_lsof_reporting_its_own_error_is_not_free(self):
+        """Exit 1 with nothing on stdout, which is also how "no match" looks."""
+        failed = MagicMock(returncode=1, stdout="", stderr="lsof: no pwd entry\n")
+        with patch.object(m.subprocess, "run", return_value=failed):
+            assert REAL_ML_PORT_STATE(3003) == m.PORT_UNKNOWN
+
+
+class TestFallbackHonoursTheWait:
+    def test_a_port_still_held_cancels_the_fallback(self, tmp_data_dir):
+        """wait_for_port_free's answer used to be discarded, and the venv was
+        started into a port the engine just killed had not let go of."""
+        with patch.object(m, "_ml_healthy", return_value=False), patch.object(
+            m, "kill_pid"
+        ), patch.object(m, "wait_for_port_free", return_value=False), patch.object(
+            m, "_venv_ml_spec"
+        ) as venv, patch.object(m, "log"):
+            pid, engine = m._ml_verify_or_fallback(
+                {"ml_port": 3003}, 111, "native Swift"
+            )
+        venv.assert_not_called()
+        assert pid is None and engine is None
+
+    def test_a_released_port_still_falls_back(self, tmp_data_dir):
+        with patch.object(m, "_ml_healthy", return_value=False), patch.object(
+            m, "kill_pid"
+        ), patch.object(m, "wait_for_port_free", return_value=True), patch.object(
+            m, "_venv_ml_spec", return_value=(["/usr/bin/true"], "/tmp", {})
+        ), patch.object(m, "start_service", return_value=222), patch.object(m, "log"):
+            pid, engine = m._ml_verify_or_fallback(
+                {"ml_port": 3003}, 111, "native Swift"
+            )
+        assert pid == 222 and engine == "Python venv"
+
+
+class TestAdoptionRunsBeforeStarting:
+    """Both watcher entry points concluded ML was absent from the pidfile alone,
+    so a launch while the pidfile was missing started a second engine into the
+    port the first one was still serving."""
+
+    def test_watch_worker_adopts_instead_of_starting(self, tmp_data_dir):
+        """The worker loop too: a live worker plus a missing ml.pid used to run
+        a full cmd_start, which restarted the worker as well."""
+        with patch.object(m, "adopt_live_ml", return_value=64933):
+            mocks = drive_watch(
+                {"worker": True, "ml": True}, ready=[True], pids={"worker": 111}
+            )
+        mocks["cmd_start"].assert_not_called()
+
+    def test_watch_without_worker_adopts_instead_of_starting(self, tmp_data_dir):
+        with patch.object(m, "read_pid", return_value=None), patch.object(
+            m, "adopt_live_ml", return_value=64933
+        ), patch.object(m, "reconcile_dashboard"), patch.object(
+            m, "_start_without_worker"
+        ) as start, patch("signal.signal"), patch(
+            "time.sleep", side_effect=KeyboardInterrupt
+        ):
+            m._watch_without_worker({"ml_port": 3003, "ml": True})
+        start.assert_not_called()
+
+    def test_ml_switched_off_is_not_adopted(self, tmp_data_dir):
+        """With ML off, _start_without_worker is what stops a leftover engine.
+        Adopting one instead would leave it running until the next cycle, and
+        report it as ours in the meantime."""
+        with patch.object(m, "read_pid", return_value=None), patch.object(
+            m, "adopt_live_ml", return_value=64933
+        ) as adopt, patch.object(m, "reconcile_dashboard"), patch.object(
+            m, "_start_without_worker"
+        ) as start, patch("signal.signal"), patch(
+            "time.sleep", side_effect=KeyboardInterrupt
+        ):
+            m._watch_without_worker({"ml_port": 3003, "ml": False})
+        adopt.assert_not_called()
+        start.assert_called_once()

--- a/tests/test_service_recovery.py
+++ b/tests/test_service_recovery.py
@@ -960,3 +960,71 @@ class TestAdoptionRunsBeforeStarting:
             m._watch_without_worker({"ml_port": 3003, "ml": False})
         adopt.assert_not_called()
         start.assert_called_once()
+
+
+class TestSpawnedServicesLeadTheirOwnSession:
+    """_signal_service decides by session leadership, so everything we spawn has
+    to be a session leader or its children stop going with it. Checked on a live
+    install for worker, ml and dashboard; this keeps start_new_session from
+    being dropped from start_service without anything noticing."""
+
+    def test_start_service_leaves_a_session_leader(self, tmp_data_dir):
+        with patch.object(m.time, "sleep"):  # skip the liveness pause
+            pid = m.start_service("ml", ["/bin/sleep", "30"], dict(os.environ), "/tmp")
+        try:
+            assert os.getsid(pid) == pid
+        finally:
+            os.kill(pid, 9)
+
+
+class TestTheGroupIsSignalledOnlyWhenWeLeadTheSession:
+    """start_service and start_dashboard pass start_new_session, so everything
+    this supervisor spawns is a session leader and only its own descendants can
+    join its process group. A process started from a shell leads its job's
+    process group but not the session, so an adopted one is signalled alone."""
+
+    def test_a_session_leader_takes_the_group(self, tmp_data_dir):
+        (tmp_data_dir["pid_dir"] / "ml.pid").write_text("4242\n")
+        with patch.object(m.os, "getsid", return_value=4242), patch.object(
+            m.os, "killpg"
+        ) as killpg, patch.object(
+            m.os, "kill", side_effect=OSError()
+        ), patch.object(m, "read_pid", return_value=4242):
+            m.kill_pid("ml")
+        assert killpg.call_args_list[0][0][0] == 4242
+
+    def test_a_pid_inside_somebody_elses_session_is_signalled_alone(self, tmp_data_dir):
+        (tmp_data_dir["pid_dir"] / "ml.pid").write_text("4242\n")
+        with patch.object(m.os, "getsid", return_value=900), patch.object(
+            m.os, "killpg"
+        ) as killpg, patch.object(
+            m.os, "kill", side_effect=[None, OSError()]
+        ) as kill, patch.object(m, "read_pid", return_value=4242):
+            m.kill_pid("ml")
+        killpg.assert_not_called()
+        assert kill.call_args_list[0][0][0] == 4242
+
+    def test_the_worker_sweep_still_runs(self, tmp_data_dir):
+        """The worker keeps its own sweep either way: it is the one service with
+        descendants that outlive their parent."""
+        (tmp_data_dir["pid_dir"] / "worker.pid").write_text("4242\n")
+        with patch.object(m.os, "getsid", return_value=900), patch.object(
+            m.os, "killpg"
+        ), patch.object(m.os, "kill", side_effect=OSError()), patch.object(
+            m, "read_pid", return_value=4242
+        ), patch.object(m, "_kill_all_worker_processes") as sweep:
+            m.kill_pid("worker")
+        sweep.assert_called_once()
+
+
+class TestOneVenvWorker:
+    def test_web_concurrency_is_pinned(self, tmp_path):
+        """Uvicorn reads WEB_CONCURRENCY and the supervisor passes its own
+        environment through, so an inherited value would fork a second copy of
+        the service, each loading its own multi-gigabyte model."""
+        venv = tmp_path / "venv" / "bin"
+        venv.mkdir(parents=True)
+        (venv / "python3").write_text("")
+        spec = m._venv_ml_spec({"ml_dir": str(tmp_path)}, {"WEB_CONCURRENCY": "4"})
+        assert spec is not None
+        assert spec[2]["WEB_CONCURRENCY"] == "1"


### PR DESCRIPTION
Stacked on #148. The first commit here is that PR; review the second, `Signal a service's process group only when the group is ours`. The two touch different parts of `__main__.py` but add tests to the same file, so they do not rebase apart cleanly.

## What this changes

`kill_pid` and `stop_all_fast` signalled the process group for every service. Both now share `_signal_service`, which signals the group only when the recorded pid leads its session. The venv ML engine is also pinned to `WEB_CONCURRENCY=1`.

Both are about the same thing: how many processes a pidfile is really speaking for.

## Signalling

`start_service` and `start_dashboard` pass `start_new_session`, so everything this supervisor spawns is a session leader, and only its own descendants can join its process group. Group signalling still reaches its children, which is what `stop_all_fast` exists for (#81).

A pid can also be one we adopted rather than spawned. `read_pid` falls back to a process scan for the worker, and `adopt_live_ml` and `start_dashboard` adopt a live listener. A process started from a shell leads its job's process group but not the session, and that group is not ours to signal.

On this Mac's live install, worker, ml and dashboard all satisfy `getsid(pid) == pid`, so nothing loses group shutdown. A test asserts `start_service` still leaves a session leader, so dropping `start_new_session` cannot silently downgrade this to pid-only.

`TestStopAllFast::test_signals_all_three_services` keeps its original assertion that all three services are signalled before any wait. Its group assertion now reads "all three, because each leads its own session", and a second test covers a pid that does not.

## Worker count

`ml/src/main.py` calls `uvicorn.run("src.main:app", ...)` with no `workers` argument, and uvicorn's `Config` reads `WEB_CONCURRENCY` when `workers` is `None` (`uvicorn/config.py`). The supervisor passes its own environment through, so an inherited value takes effect.

I ran a bare uvicorn app the same way with `WEB_CONCURRENCY=3`: `lsof` showed four processes on the listening socket. Several owners for one port, under a master that `ml.pid` does not name, each loading its own model.

The pin applies to what we start. It does not reach an engine that is already running, which is the case `_signal_service` has to stay correct for.

## Tests

`pytest -m "not slow"` on an M1 MacBook Air running the accelerator, with the `ml/` submodule checked out: 455 passed, 20 skipped, 11 deselected, 0 failed. Without the submodule, `TestDashboardDependenciesAreAvailable` fails with `FileNotFoundError` on `ml/requirements.txt`, here and on `main` alike — it reads that file directly and `ml` is a gitlink, so a fresh worktree leaves it empty.

## Checklist

- [x] Ran `pytest -v -m "not slow"` locally — all tests pass
- [x] Tested on a real Mac with the accelerator running
- [x] No unrelated changes bundled in
