### PR TITLE
Report why a native-ml bundle build failed, and stage the bundle

### DIFF
--- a/native-ml/scripts/build_bundle.sh
+++ b/native-ml/scripts/build_bundle.sh
@@ -7,13 +7,30 @@ set -euo pipefail
 cd "$(dirname "$0")/.."   # native-ml/
 export PATH=/opt/homebrew/bin:$PATH
 
-OUT="${1:-bundle}"
+DEST="${1:-bundle}"; DEST="${DEST%/}"
+# Stage the bundle beside the destination and promote it only once every check
+# below has passed. Building straight into $DEST meant a run that failed after
+# the copy left $DEST holding a bundle this script had just rejected, and a run
+# that failed before it left the previous bundle sitting there. Callers hand
+# $DEST to something that runs it (install_native.sh points it at
+# ~/.immich-accelerator/native-ml), so neither state is distinguishable from a
+# good build.
+OUT="$DEST.staging"
+trap 'rm -rf "$OUT"' EXIT
 ORT="$(brew --prefix onnxruntime)"
 METALLIB="${MLX_METALLIB:-$(find /opt/homebrew -name mlx.metallib 2>/dev/null | head -1)}"
 [ -n "$METALLIB" ] || { echo "mlx.metallib not found (set MLX_METALLIB)"; exit 1; }
 
 echo "building release..."
-swift build -c release >/dev/null
+# swift build reports compile errors on stdout, not stderr, so `>/dev/null`
+# discarded the diagnostics along with the progress lines and a broken build
+# failed without printing anything at all. Both callers redirect this script's
+# stdout to /dev/null as well, so nothing downstream could show them either.
+# Keep the quiet happy path; print the build output when the build fails.
+if ! build_log="$(swift build -c release 2>&1)"; then
+    printf '%s\n' "$build_log" >&2
+    echo "ERROR: swift build -c release failed; $DEST not updated" >&2; exit 1
+fi
 
 rm -rf "$OUT"; mkdir -p "$OUT"
 cp .build/release/immich-ml-native "$OUT/"
@@ -101,7 +118,6 @@ for f in "$OUT/immich-ml-native" "$OUT"/*.dylib; do
     codesign --verify "$f" 2>/dev/null || { echo "ERROR: codesign --verify failed on $(basename "$f")"; exit 1; }
 done
 
-echo "bundle -> $OUT"
 ls -la "$OUT"
 
 # Fail the build unless the bundle is genuinely self-contained. The original
@@ -129,3 +145,6 @@ for f in "$OUT/immich-ml-native" "$OUT"/*.dylib; do
 done
 [ "$leak" = 0 ] || { echo "ERROR: bundle is not self-contained"; exit 1; }
 echo "OK: self-contained ($(ls "$OUT"/*.dylib | wc -l | tr -d ' ') vendored dylibs; no brew load deps, no brew/toolchain rpaths, no unresolved @rpath deps)"
+
+rm -rf "$DEST"; mv "$OUT" "$DEST"
+echo "bundle -> $DEST"


### PR DESCRIPTION
## The problem

`native-ml/scripts/build_bundle.sh` built with `swift build -c release >/dev/null`.
swiftpm writes its diagnostics to **stdout**, not stderr, so that redirect
discarded the compile errors along with the progress lines. A build with a
syntax error printed `building release...`, exited 1, and wrote nothing to
stderr. Both callers (`install_native.sh`, `release_bundle.sh`) redirect this
script's stdout to `/dev/null` too, so they could not surface the errors either.

`set -euo pipefail` does fire and both callers inherit the failure, so the exit
status was never wrong. What was missing was any statement of what happened:
the destination directory keeps the previous bundle, and `install_native.sh`
points that destination at `~/.immich-accelerator/native-ml`, the directory the
accelerator runs the binary from. I lost three rounds of debugging to an old
binary that looked like a new one.

Separately, the script built straight into the destination — `rm -rf "$OUT"`
ran before the copy, the relink, the codesign check and the self-contained
check. A failure at any of those points left the destination holding a bundle
the script had just rejected.

## Reproducing

On Apple Silicon, from `native-ml/`, with a bundle already built at `$DEST`:

```bash
printf '\nlet ) = broken\n' >> Sources/immich-ml-native/Server.swift
bash scripts/build_bundle.sh "$DEST" >/tmp/out 2>/tmp/err
```

Before this change:

```
exit status : 1
/tmp/out    : building release...
/tmp/err    : (0 bytes)
$DEST       : unchanged, same sha256 and mtime as the previous good build
```

To confirm where the diagnostics went, `swift build -c release >/dev/null 2>/tmp/err`
on the same broken tree prints nothing and exits 1; splitting the streams gives
0 bytes on stderr and the `error: expected pattern` lines on stdout.

For the rejected-bundle half I forced the existing self-contained check to fail
(`leak=1`) in a copy of the script and ran it against a destination holding a
known-good bundle:

```
old script: exit 1, "ERROR: bundle is not self-contained",
            destination sha256 2613f81c... -> 519034bb... (replaced by the rejected bundle)
```

## The change

- Capture the build output and print it to stderr when the build fails, then
  fail with a message naming the destination that was not updated. A successful
  build stays as quiet as it was.
- Build into `<dest>.staging` and `mv` it into place only after the last check
  passes. A `trap ... EXIT` removes the staging directory on any exit.

## Verification

All on an M1, Swift 6.3.3, brew onnxruntime.

Failure path, same repro as above:

```
exit status : 1
stdout      : building release...
stderr      : ...Server.swift:334:5: error: expected pattern
              ERROR: swift build -c release failed; <dest> not updated
$DEST       : unchanged (sha256 519034bb... before and after)
staging dir : removed
```

Rejected-bundle path, same forced `leak=1` probe against the patched script:

```
exit 1, "ERROR: bundle is not self-contained",
destination sha256 2613f81c... -> 2613f81c... (unchanged), no staging dir left
```

Happy path, from a wiped `.build`:

```
rm -rf .build && bash scripts/build_bundle.sh /tmp/cleanbundle
-> exit 0, "OK: self-contained (85 vendored dylibs; no brew load deps,
   no brew/toolchain rpaths, no unresolved @rpath deps)"
-> bundle -> /tmp/cleanbundle
```

I then copied that bundle to a different directory and ran it, to check the
relink still holds: `codesign --verify` passes, `DYLD_PRINT_LIBRARIES=1` shows
onnxruntime resolving from beside the binary with no missing images, and
`./immich-ml-native serve 3998` answers `/health` with
`{"status":"healthy","checks":{"clip":"ok","vision_framework":"ok","face_recognition":"ok"}}`.
A rerun over an already-populated destination also succeeds and leaves the
expected binary in place.

`pytest -m "not slow"` at the repo root: 442 passed, 2 skipped. No test touches
this script.

## Notes

- No `VERSION` bump: `ci.yml` exempts fork PRs from `version-bump` on purpose.
- I left the existing `ERROR: codesign ...` and `ERROR: bundle is not
  self-contained` messages on stdout rather than moving them to stderr. They are
  invisible under the callers' `>/dev/null` for the same reason the build
  diagnostics were, but that is a separate change and I did not want to widen
  this diff. Happy to do it here if you prefer.
