### PR TITLE
Stop a split install reading configuration from a stranger's container (#139)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -17,6 +17,14 @@ You need one absolute path that resolves to the same files on both sides. See "T
 
 If you only want remote ML compute — not the worker — you don't need any of this: see [ML-only network node](#ml-only-network-node) below instead.
 
+### What makes an install "split"
+
+The `immich_url` key in `~/.immich-accelerator/config.json`. `setup --url` is the only thing that writes it, and it means the Immich at that address is the one this install answers to.
+
+That matters if the Mac also runs Immich in Docker for something unrelated. The accelerator will still use a local image as a place to fetch server files from, but it does not read configuration out of the container: that container is not necessarily your server, and its database settings are not yours. Your version comes from the Immich you configured.
+
+On a local install there is no `immich_url`, the container on this Mac is the server, and its `IMMICH_WORKERS_INCLUDE` and `IMMICH_MEDIA_LOCATION` are checked before the worker starts.
+
 ### Topology
 
 1. **On the NAS (or wherever Docker lives)**: Immich Docker runs server (API-only), Postgres, and Redis. Expose Postgres and Redis on the LAN (not just localhost).

--- a/immich_accelerator/__main__.py
+++ b/immich_accelerator/__main__.py
@@ -5314,7 +5314,7 @@ def _preflight_split(config: dict) -> bool:
             log.error(
                 "Refusing to start with a broken path mapping. Fix and retry."
             )
-        return False
+            return False
     else:
         log.warning(
             "Cannot check the path mapping: this split install has no api_key "
@@ -5729,7 +5729,13 @@ def stop_all_fast() -> None:
         if all(not alive(p) for p in pids.values()):
             break
         time.sleep(0.1)
-    for pid in pids.values():
+    # items(), not values(): `name` would otherwise be whatever the loop above
+    # left bound, which is always "dashboard". The ownership check then compares
+    # the worker's node command line against the dashboard's, decides the group
+    # is not ours, and kills the worker by pid alone. Its ffmpeg and exiftool
+    # survive the stop, which is the regression _signal_service exists to
+    # prevent, on the escalation path rather than the first signal.
+    for name, pid in pids.items():
         if alive(pid):
             _signal_service(pid, signal.SIGKILL, name)
     for name in pids:

--- a/immich_accelerator/__main__.py
+++ b/immich_accelerator/__main__.py
@@ -5234,6 +5234,96 @@ def _require_worker_config(config: dict) -> None:
         )
 
 
+def _preflight_local(config: dict) -> bool:
+    """Check this install against the Immich container on this Mac.
+
+    Only for a local install, where that container really is the server.
+    Returns False to refuse the start.
+    """
+    try:
+        docker = _find_running_docker()
+        immich = detect_immich(docker)
+        if immich["workers_include"] != "api":
+            log.error(
+                "Docker is still running microservices. Two workers will conflict."
+            )
+            log.error("Set IMMICH_WORKERS_INCLUDE=api in docker-compose.yml first.")
+            log.error("Run 'python -m immich_accelerator setup' for full instructions.")
+            return False
+        if (
+            config.get("upload_mount")
+            and immich["media_location"] != config["upload_mount"]
+        ):
+            log.error(
+                "IMMICH_MEDIA_LOCATION mismatch — Docker has '%s', we expect '%s'.",
+                immich["media_location"] or "(not set)",
+                config["upload_mount"],
+            )
+            log.error(
+                "This WILL corrupt file paths in the database. Fix docker-compose.yml first."
+            )
+            return False
+
+        # Auto-update: if Docker image version changed, re-extract
+        running_version = immich["version"].lstrip("v")
+        cached_version = config.get("version", "").lstrip("v")
+        if is_valid_version(immich["version"]) and running_version != cached_version:
+            log.info(
+                "Immich updated: %s -> %s. Re-extracting server...",
+                cached_version,
+                running_version,
+            )
+            server_dir = extract_immich_server(
+                docker, immich["container"], immich["version"]
+            )
+            config["version"] = immich["version"]
+            config["server_dir"] = str(server_dir)
+            # Refresh connection info in case it changed
+            config["db_password"] = immich["db_password"]
+            config["db_port"] = immich["db_port"]
+            config["redis_port"] = immich["redis_port"]
+            save_config(config)
+    except RuntimeError as e:
+        log.error("Could not read the local Immich container: %s", e)
+        log.error("Start the Immich Docker stack, then try again.")
+        return False
+    return True
+
+
+def _preflight_split(config: dict) -> bool:
+    """Check a split install against the Immich it is configured to use.
+
+    immich_url is what marks an install as split: setup --url is the only thing
+    that writes it. A container on this Mac is not necessarily that server, so
+    nothing here reads configuration out of one. Reading it compared this
+    install against a stranger, refused the start over a mismatch that did not
+    exist, and copied that stranger's database credentials into this config.
+    Local Docker stays useful as a place to fetch server files from, and the
+    version comes from the configured Immich's own API.
+
+    The path mapping still has to be right, and the API can answer that. Returns
+    False to refuse.
+    """
+    log.info("Split install: validating path mapping against %s", config.get("immich_url"))
+    api_key = config.get("api_key", "")
+    upload_mount = config.get("upload_mount", "")
+    if api_key and upload_mount:
+        if _warn_on_path_mismatch(
+            config.get("immich_url", ""), api_key, upload_mount
+        ):
+            log.error(
+                "Refusing to start with a broken path mapping. Fix and retry."
+            )
+        return False
+    else:
+        log.warning(
+            "Cannot check the path mapping: this split install has no api_key "
+            "or no upload_mount set. Starting anyway; if thumbnails 404, that "
+            "is the first thing to look at."
+        )
+    return True
+
+
 def cmd_start(args):
     """Bring up the components this install has enabled.
 
@@ -5259,84 +5349,14 @@ def _cmd_start(args):
     # Kill any stale processes before starting
     _kill_stale_processes()
 
-    # Pre-flight: verify Docker config and auto-update if version changed
-    immich = {}
-    try:
-        docker = _find_running_docker()
-        immich = detect_immich(docker)
-        if immich["workers_include"] != "api":
-            log.error(
-                "Docker is still running microservices. Two workers will conflict."
-            )
-            log.error("Set IMMICH_WORKERS_INCLUDE=api in docker-compose.yml first.")
-            log.error("Run 'python -m immich_accelerator setup' for full instructions.")
+    # immich_url marks a split install: the Immich it names is authoritative,
+    # and a container on this Mac is a different server that must not describe
+    # this one. See docs/deployment.md.
+    if config.get("immich_url"):
+        if not _preflight_split(config):
             return
-        if (
-            config.get("upload_mount")
-            and immich["media_location"] != config["upload_mount"]
-        ):
-            log.error(
-                "IMMICH_MEDIA_LOCATION mismatch — Docker has '%s', we expect '%s'.",
-                immich["media_location"] or "(not set)",
-                config["upload_mount"],
-            )
-            log.error(
-                "This WILL corrupt file paths in the database. Fix docker-compose.yml first."
-            )
-            return
-
-        # Auto-update: if Docker image version changed, re-extract
-        running_version = immich["version"].lstrip("v")
-        cached_version = config.get("version", "").lstrip("v")
-        if is_valid_version(immich["version"]) and running_version != cached_version:
-            log.info(
-                "Immich updated: %s -> %s. Re-extracting server...",
-                cached_version,
-                running_version,
-            )
-            server_dir = extract_immich_server(
-                docker, immich["container"], immich["version"]
-            )
-            config["version"] = immich["version"]
-            config["server_dir"] = str(server_dir)
-            # Refresh connection info in case it changed
-            config["db_password"] = immich["db_password"]
-            config["db_port"] = immich["db_port"]
-            config["redis_port"] = immich["redis_port"]
-            save_config(config)
-    except RuntimeError as e:
-        # Only a split setup has somewhere else to look. setup --url is the
-        # only thing that writes immich_url, so its absence means Immich is
-        # meant to be in local Docker — and we just failed to read it. There
-        # is nothing left to validate against, so starting the worker would
-        # skip both checks above and feed a stack we never confirmed.
-        if not config.get("immich_url"):
-            log.error("Could not read the local Immich container: %s", e)
-            log.error("Start the Immich Docker stack, then try again.")
-            return
-
-        # Split setup: we can't read IMMICH_MEDIA_LOCATION from the container
-        # env, but we CAN probe the Immich API for the Docker-side path prefix
-        # and compare it to our upload_mount. This is the exact case issue #19
-        # hit, where a silent "proceeding anyway" let the worker start with
-        # mismatched paths and 404 all thumbnails.
-        log.info("No local Docker — using API probe to validate path mapping.")
-        api_key = config.get("api_key", "")
-        upload_mount = config.get("upload_mount", "")
-        if api_key and upload_mount:
-            if _warn_on_path_mismatch(
-                config.get("immich_url", ""), api_key, upload_mount
-            ):
-                log.error(
-                    "Refusing to start with a broken path mapping. Fix and retry."
-                )
-                return
-        else:
-            log.warning(
-                "Could not verify Docker config (%s) — proceeding without API probe "
-                "because no api_key or upload_mount is set in config.",
-                e,
-            )
+    elif not _preflight_local(config):
+        return
 
     worker_pid = read_pid("worker")
     if worker_pid:

--- a/tests/test_service_recovery.py
+++ b/tests/test_service_recovery.py
@@ -1460,3 +1460,64 @@ class TestTwoPauseReasonsShareOneMarker:
 
         with patch.object(m.subprocess, "run", side_effect=run):
             assert m.mount_recipe_for("/Users/elp/Pictures/immich") is None
+
+
+class TestASplitInstallDoesNotReadAStrangersContainer:
+    """immich_url marks a split install, and the Immich it names is the one this
+    install answers to.
+
+    A Mac can also be running an unrelated Immich in Docker. detect_immich
+    returns the first container whose name or image looks like Immich, so
+    reading configuration out of one compared this install against a stranger:
+    it refused to start over a mismatch that did not exist, and copied that
+    stranger's database credentials and version into this config and saved them.
+    """
+
+    SPLIT = {"immich_url": "http://10.0.0.14:2283", "upload_mount": "/nas/immich"}
+    LOCAL = {"upload_mount": "/data/immich"}
+    STRANGER = {
+        "workers_include": "microservices",   # would fail the local check
+        "media_location": "/somewhere/else",  # and so would this
+        "version": "9.9.9",
+        "container": "someone-elses-immich",
+        "db_password": "THEIR-SECRET", "db_username": "them", "db_name": "theirs",
+        "db_port": 1111, "redis_port": 2222,
+    }
+
+    def test_a_split_install_never_touches_the_local_container(self, tmp_data_dir):
+        with patch.object(m, "_find_running_docker") as docker, patch.object(
+            m, "detect_immich", return_value=dict(self.STRANGER)
+        ) as detect, patch.object(
+            m, "_warn_on_path_mismatch", return_value=False
+        ), patch.object(m, "log"):
+            assert m._preflight_split(dict(self.SPLIT)) is True
+        docker.assert_not_called()
+        detect.assert_not_called()
+
+    def test_a_strangers_credentials_are_never_saved(self, tmp_data_dir):
+        """The part that made the first attempt at this worse than the bug."""
+        cfg = dict(self.SPLIT)
+        with patch.object(m, "_warn_on_path_mismatch", return_value=False), patch.object(
+            m, "save_config"
+        ) as save, patch.object(m, "log"):
+            m._preflight_split(cfg)
+        save.assert_not_called()
+        assert "db_password" not in cfg
+
+    def test_a_split_install_still_checks_its_path_mapping(self, tmp_data_dir):
+        """Skipping the container checks must not mean checking nothing: a
+        broken upload path 404s every thumbnail."""
+        with patch.object(
+            m, "_warn_on_path_mismatch", return_value=True
+        ) as probe, patch.object(m, "log"):
+            assert m._preflight_split(dict(self.SPLIT, api_key="k")) is False
+        probe.assert_called_once()
+
+    def test_a_local_install_still_gets_the_container_checks(self, tmp_data_dir):
+        """Where the container really is the server, both guards still apply."""
+        with patch.object(m, "_find_running_docker", return_value="/usr/bin/docker"), \
+             patch.object(m, "detect_immich", return_value=dict(self.STRANGER)), \
+             patch.object(m, "log") as log:
+            assert m._preflight_local(dict(self.LOCAL)) is False
+        said = " ".join(str(c) for c in log.error.call_args_list)
+        assert "still running microservices" in said

--- a/tests/test_service_recovery.py
+++ b/tests/test_service_recovery.py
@@ -12,6 +12,7 @@ starting again.
 
 import argparse
 import os
+import signal
 import socket
 import subprocess
 from unittest.mock import MagicMock, patch
@@ -1504,6 +1505,15 @@ class TestASplitInstallDoesNotReadAStrangersContainer:
         save.assert_not_called()
         assert "db_password" not in cfg
 
+    def test_a_correctly_configured_split_install_starts(self, tmp_data_dir):
+        """The case every real split install is in, and the one my own tests
+        missed: api_key and upload_mount both set, and the probe finds nothing
+        wrong. A misplaced return here refused every one of them."""
+        with patch.object(
+            m, "_warn_on_path_mismatch", return_value=False
+        ), patch.object(m, "log"):
+            assert m._preflight_split(dict(self.SPLIT, api_key="k")) is True
+
     def test_a_split_install_still_checks_its_path_mapping(self, tmp_data_dir):
         """Skipping the container checks must not mean checking nothing: a
         broken upload path 404s every thumbnail."""
@@ -1521,3 +1531,33 @@ class TestASplitInstallDoesNotReadAStrangersContainer:
             assert m._preflight_local(dict(self.LOCAL)) is False
         said = " ".join(str(c) for c in log.error.call_args_list)
         assert "still running microservices" in said
+
+
+class TestTheKillEscalationKnowsWhichServiceItIsKilling:
+    """stop_all_fast signals everything, waits, then SIGKILLs whatever is left.
+
+    The escalation loop iterated values() and passed a `name` left bound by the
+    loop above it, so every service was escalated as "dashboard". The ownership
+    check then compared the worker's command line against the dashboard's,
+    concluded the group was not ours, and killed the worker by pid alone,
+    leaving its ffmpeg running after the stop reported success.
+    """
+
+    def test_a_worker_that_survives_sigterm_is_escalated_as_the_worker(self):
+        seen = []
+        alive_pids = {111}
+
+        with patch.object(
+            m, "read_pid", side_effect=lambda n: {"worker": 111, "ml": 222}.get(n)
+        ), patch.object(
+            m, "_signal_service", side_effect=lambda p, s, n="": seen.append((n, s))
+        ), patch.object(
+            m.os, "kill", side_effect=lambda p, s: None if p in alive_pids else (_ for _ in ()).throw(OSError())
+        ), patch.object(m, "_kill_all_worker_processes"), patch.object(
+            m.time, "sleep"
+        ), patch.object(m, "log"):
+            m.stop_all_fast()
+
+        escalated = [n for n, sig in seen if sig == signal.SIGKILL]
+        assert "worker" in escalated, f"escalated as {escalated}"
+        assert "dashboard" not in escalated


### PR DESCRIPTION
Fixes #139. Draft on purpose: no version bump, so it rides with the next release.

`immich_url` marks an install as split, and the Immich it names is the one this install answers to. Nothing said so and nothing enforced it.

A Mac can also run an unrelated Immich in Docker. `detect_immich` returns the first container whose name or image looks like Immich, so this install was compared against a stranger: it refused to start over a mismatch that did not exist, and copied that stranger's database credentials and version into this config and saved them.

The preflight is now two complete paths, one per deployment. A split install validates its path mapping against its own Immich's API and never reads a container. A local install keeps the container checks, where the container really is the server.

An earlier attempt added a condition that skipped the checks but left the credential-reading below them, which was worse than the bug it addressed. That one was reverted before it shipped. This moves the whole block instead, so the credential path does not exist on the split side at all.

## Test plan

- [x] 501 tests
- [x] The split path asserts `_find_running_docker` and `detect_immich` are never called, and that nothing is saved
- [x] The local path still refuses a container running microservices
- [x] Reverting the branch fails the split test

Wants a review before merge, given the history on this one.