### PR TITLE
Make the IMMICH_ACCEL* settings reachable on a Homebrew install

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -171,6 +171,8 @@ Put them in the `env` block of `~/.immich-accelerator/config.json`:
 
 They are passed to the worker and the ML service, and the accelerator reads its own from there too. Restart with `brew services restart immich-accelerator` to apply.
 
+A real environment variable still wins, so running the accelerator by hand with one exported does what you would expect. The config block exists because the environment cannot be reached on a Homebrew install, not to outrank it.
+
 Setting them in the shell environment does not work on a Homebrew install, which is why this exists: `brew services` generates the launch agent, it carries no environment, `launchctl setenv` does not reach it, and editing the plist is undone the next time the service restarts.
 
 Only `IMMICH_ACCEL*` names are accepted. Everything else a service needs is worked out at startup, and anything else in that block is ignored with a warning.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -156,6 +156,25 @@ The cap is close to free, because the parallelism saturates early. On an M4 with
 
 ## Configuration details
 
+### Setting `IMMICH_ACCEL*` variables
+
+Put them in the `env` block of `~/.immich-accelerator/config.json`:
+
+```json
+{
+  "env": {
+    "IMMICH_ACCELERATOR_HEIC_DECODE_CONCURRENCY": "2",
+    "IMMICH_ACCEL_ML_THREADS": "4"
+  }
+}
+```
+
+They are passed to the worker and the ML service, and the accelerator reads its own from there too. Restart with `brew services restart immich-accelerator` to apply.
+
+Setting them in the shell environment does not work on a Homebrew install, which is why this exists: `brew services` generates the launch agent, it carries no environment, `launchctl setenv` does not reach it, and editing the plist is undone the next time the service restarts.
+
+Only `IMMICH_ACCEL*` names are accepted. Everything else a service needs is worked out at startup, and anything else in that block is ignored with a warning.
+
 ### Understanding `IMMICH_MEDIA_LOCATION`
 
 This is the directory Immich uses as its media root. It contains these subdirectories: `upload/`, `thumbs/`, `encoded-video/`, `library/`, `profile/`, `backups/`. Both Docker and the native worker must see this directory at the same absolute path. Setup handles this automatically for same-machine installs.

--- a/immich_accelerator/__main__.py
+++ b/immich_accelerator/__main__.py
@@ -2660,7 +2660,13 @@ def start_service(name: str, cmd: list[str], env: dict, cwd: str) -> int:
     """Start a background service and track its PID. Returns PID."""
     # Applied here rather than at each caller, so every service gets them and a
     # service added later does not have to remember.
-    env = {**env, **config_env()}
+    #
+    # config first, so a real environment variable still wins. The file exists
+    # because the environment cannot be reached on a Homebrew install, not to
+    # outrank it: someone who exports one in a shell and runs the accelerator by
+    # hand means it, and having a file quietly beat them is the opposite of what
+    # everything else on a Unix box does.
+    env = {**config_env(), **env}
     LOG_DIR.mkdir(parents=True, exist_ok=True)
     log_file = LOG_DIR / f"{name}.log"
     cap_log(log_file)  # don't inherit a giant log across a (re)start
@@ -5872,6 +5878,9 @@ def int_setting(name: str, default: int, config: dict | None = None) -> int:
     cannot be set at all (see config_env), which left these documented and
     unreachable.
     """
+    # Same order as start_service: a real environment variable wins.
+    if os.environ.get(name) is not None:
+        return _int_env(name, default)
     raw = config_env(config).get(name)
     if raw is not None:
         try:

--- a/immich_accelerator/__main__.py
+++ b/immich_accelerator/__main__.py
@@ -2614,8 +2614,53 @@ def ensure_media_ready(config: dict) -> bool:
     return False
 
 
+# Only our own variables can be set this way. Everything else a service needs
+# is worked out here (ports, database settings, the model directory), and a
+# config file that could quietly override those would be a way to break an
+# install from a place nobody thinks to look.
+_CONFIG_ENV_PREFIX = "IMMICH_ACCEL"
+
+
+def config_env(config: dict | None = None) -> dict:
+    """The IMMICH_ACCEL* variables set in config.json.
+
+    They are documented, and until now there was no supported way to set them on
+    the standard Homebrew install: brew services generates the plist, it carries
+    no EnvironmentVariables, launchctl setenv does not reach the agent, and any
+    hand edit is undone the next time the service restarts. The only way through
+    was to wrap the binary in a script. config.json survives upgrades and
+    restarts and is already where settings live. Reported by RxChi1d.
+    """
+    if config is None:
+        # start_service runs before setup has written anything, and on a machine
+        # with no config at all. No config simply means nothing set here.
+        try:
+            config = load_config()
+        except (RuntimeError, OSError, ValueError):
+            return {}
+    raw = config.get("env")
+    if not isinstance(raw, dict):
+        return {}
+    out = {}
+    for key, value in raw.items():
+        name = str(key)
+        if name.startswith(_CONFIG_ENV_PREFIX):
+            out[name] = str(value)
+        else:
+            log.warning(
+                "Ignoring %s in the config \"env\" block: only %s* variables can "
+                "be set there.",
+                name,
+                _CONFIG_ENV_PREFIX,
+            )
+    return out
+
+
 def start_service(name: str, cmd: list[str], env: dict, cwd: str) -> int:
     """Start a background service and track its PID. Returns PID."""
+    # Applied here rather than at each caller, so every service gets them and a
+    # service added later does not have to remember.
+    env = {**env, **config_env()}
     LOG_DIR.mkdir(parents=True, exist_ok=True)
     log_file = LOG_DIR / f"{name}.log"
     cap_log(log_file)  # don't inherit a giant log across a (re)start
@@ -5819,6 +5864,23 @@ def cmd_update(_args):
     log.info("Updated to %s. Run: python -m immich_accelerator start", running)
 
 
+def int_setting(name: str, default: int, config: dict | None = None) -> int:
+    """An integer knob, from config.json first and the environment second.
+
+    The module-level constants below are bound at import, so a value in
+    config.json could never reach them. On a Homebrew install the environment
+    cannot be set at all (see config_env), which left these documented and
+    unreachable.
+    """
+    raw = config_env(config).get(name)
+    if raw is not None:
+        try:
+            return int(raw)
+        except ValueError:
+            log.warning("Ignoring %s=%r in config: not a whole number.", name, raw)
+    return _int_env(name, default)
+
+
 def _int_env(name: str, default: int) -> int:
     """Parse an int env var, falling back to default on a missing/bad value.
 
@@ -6045,7 +6107,9 @@ def _watch_worker(config: dict) -> str | None:
     mid-flight, so cmd_watch can hand over to the worker-free loop."""
     log.info("Watching services (Ctrl+C to stop)...")
 
-    if FD_RESTART_THRESHOLD > 0 and _LIBPROC is None:
+    fd_threshold = int_setting("IMMICH_ACCEL_FD_RESTART_THRESHOLD", FD_RESTART_THRESHOLD, config)
+    fd_cooldown = int_setting("IMMICH_ACCEL_FD_RESTART_COOLDOWN", FD_RESTART_COOLDOWN, config)
+    if fd_threshold > 0 and _LIBPROC is None:
         log.warning(
             "fd-leak watchdog (#89) inactive: libproc unavailable, cannot read "
             "worker fd counts on this system."
@@ -6309,12 +6373,12 @@ def _watch_worker(config: dict) -> str | None:
             # exhausts the table and crashes it with `spawn EBADF`. Sum fds
             # across all worker processes (the leak may be in a sibling), and
             # cool down between restarts so a fast leak can't thrash.
-            if FD_RESTART_THRESHOLD > 0:
+            if fd_threshold > 0:
                 fd_total = _worker_fd_total()
-                if fd_total is not None and fd_total >= FD_RESTART_THRESHOLD:
+                if fd_total is not None and fd_total >= fd_threshold:
                     cooled = (
                         last_fd_restart is None
-                        or time.monotonic() - last_fd_restart >= FD_RESTART_COOLDOWN
+                        or time.monotonic() - last_fd_restart >= fd_cooldown
                     )
                     if cooled:
                         last_fd_restart = time.monotonic()
@@ -6323,7 +6387,7 @@ def _watch_worker(config: dict) -> str | None:
                             "handles on some media (#89). Restarting the worker "
                             "before it exhausts the fd table and crashes.",
                             fd_total,
-                            FD_RESTART_THRESHOLD,
+                            fd_threshold,
                         )
                         kill_pid("worker")
                         try:
@@ -6342,7 +6406,7 @@ def _watch_worker(config: dict) -> str | None:
                             "Worker fd count %d high but within restart "
                             "cooldown (%ds); not restarting yet.",
                             fd_total,
-                            FD_RESTART_COOLDOWN,
+                            fd_cooldown,
                         )
 
             # Check worker

--- a/tests/test_service_recovery.py
+++ b/tests/test_service_recovery.py
@@ -1507,3 +1507,27 @@ class TestSettingsReachableOnAHomebrewInstall:
         cfg = {"env": {"IMMICH_ACCEL_FD_RESTART_THRESHOLD": "lots"}}
         with patch.object(m, "log"):
             assert m.int_setting("IMMICH_ACCEL_FD_RESTART_THRESHOLD", 10000, cfg) == 10000
+
+    def test_a_real_environment_variable_beats_the_config_file(self, tmp_data_dir):
+        """The file exists because the environment cannot be reached on a
+        Homebrew install, not to outrank it. Someone exporting one in a shell
+        and running this by hand means it."""
+        cfg = {"env": {"IMMICH_ACCELERATOR_HEIC_DECODE_CONCURRENCY": "3"}}
+        with patch.object(m, "load_config", return_value=cfg), patch.object(
+            m.subprocess, "Popen"
+        ) as popen, patch.object(m, "write_pid"), patch.object(
+            m.time, "sleep"
+        ), patch.object(m, "log"):
+            popen.return_value = MagicMock(pid=1, poll=MagicMock(return_value=None))
+            m.start_service(
+                "worker", ["/bin/true"],
+                {"IMMICH_ACCELERATOR_HEIC_DECODE_CONCURRENCY": "8"}, "/tmp",
+            )
+        assert popen.call_args.kwargs["env"][
+            "IMMICH_ACCELERATOR_HEIC_DECODE_CONCURRENCY"
+        ] == "8"
+
+    def test_the_same_holds_for_the_watcher_s_own_knobs(self, tmp_data_dir):
+        cfg = {"env": {"IMMICH_ACCEL_FD_RESTART_THRESHOLD": "500"}}
+        with patch.dict(m.os.environ, {"IMMICH_ACCEL_FD_RESTART_THRESHOLD": "900"}):
+            assert m.int_setting("IMMICH_ACCEL_FD_RESTART_THRESHOLD", 10000, cfg) == 900

--- a/tests/test_service_recovery.py
+++ b/tests/test_service_recovery.py
@@ -1460,3 +1460,50 @@ class TestTwoPauseReasonsShareOneMarker:
 
         with patch.object(m.subprocess, "run", side_effect=run):
             assert m.mount_recipe_for("/Users/elp/Pictures/immich") is None
+
+
+class TestSettingsReachableOnAHomebrewInstall:
+    """The IMMICH_ACCEL* variables are documented, and on the standard install
+    there was no supported way to set any of them: brew services generates the
+    plist, it carries no EnvironmentVariables, launchctl setenv does not reach
+    the agent, and a hand edit is undone by the next restart. The only way
+    through was wrapping the binary in a script. Reported by RxChi1d on #137.
+    """
+
+    def test_a_setting_in_config_reaches_a_spawned_service(self, tmp_data_dir):
+        cfg = {"env": {"IMMICH_ACCELERATOR_HEIC_DECODE_CONCURRENCY": "3"}}
+        with patch.object(m, "load_config", return_value=cfg), patch.object(
+            m.subprocess, "Popen"
+        ) as popen, patch.object(m, "write_pid"), patch.object(
+            m.time, "sleep"
+        ), patch.object(m, "log"):
+            popen.return_value = MagicMock(pid=4242, poll=MagicMock(return_value=None))
+            m.start_service("worker", ["/bin/true"], {"PATH": "/usr/bin"}, "/tmp")
+        passed = popen.call_args.kwargs["env"]
+        assert passed["IMMICH_ACCELERATOR_HEIC_DECODE_CONCURRENCY"] == "3"
+        assert passed["PATH"] == "/usr/bin", "the rest of the environment survives"
+
+    def test_only_our_own_variables_can_be_set_there(self, tmp_data_dir):
+        """Everything else a service needs is worked out here. A config file
+        that could override the database or the port would be a way to break an
+        install from a place nobody thinks to look."""
+        cfg = {"env": {"DB_PASSWORD": "nope", "PATH": "/evil", "IMMICH_ACCEL_X": "1"}}
+        with patch.object(m, "log"):
+            got = m.config_env(cfg)
+        assert got == {"IMMICH_ACCEL_X": "1"}
+
+    def test_no_config_at_all_is_not_an_error(self, tmp_data_dir):
+        """start_service runs before setup has written anything."""
+        with patch.object(m, "load_config", side_effect=RuntimeError("not set up")):
+            assert m.config_env() == {}
+
+    def test_the_watcher_reads_its_own_knobs_from_config(self, tmp_data_dir):
+        """These are bound at import, so a value in config could never reach
+        them however it was set."""
+        cfg = {"env": {"IMMICH_ACCEL_FD_RESTART_THRESHOLD": "500"}}
+        assert m.int_setting("IMMICH_ACCEL_FD_RESTART_THRESHOLD", 10000, cfg) == 500
+
+    def test_a_value_that_is_not_a_number_falls_back(self, tmp_data_dir):
+        cfg = {"env": {"IMMICH_ACCEL_FD_RESTART_THRESHOLD": "lots"}}
+        with patch.object(m, "log"):
+            assert m.int_setting("IMMICH_ACCEL_FD_RESTART_THRESHOLD", 10000, cfg) == 10000


### PR DESCRIPTION
Raised by @RxChi1d on #137. Draft: no version bump, rides with the next release alongside #152.

The `IMMICH_ACCEL*` variables are documented and there was no supported way to set any of them on the standard install. `brew services` generates the launch agent and it carries no environment, `launchctl setenv` does not reach it, editing the plist is undone by the next restart, and bootout/bootstrap needs root. He ended up wrapping the binary in a shell script, which is a fair signal that the documentation was writing cheques the product could not cash.

They go in an `env` block in `config.json` now:

```json
{ "env": { "IMMICH_ACCELERATOR_HEIC_DECODE_CONCURRENCY": "2" } }
```

Applied in `start_service`, so every service gets them and one added later does not have to remember. The two knobs the watcher reads for itself are read from there too, since those are bound at import and no value in config could otherwise reach them.

Only `IMMICH_ACCEL*` names are accepted. Everything else a service needs is worked out at startup, and a config file that could override the database settings or the port would be a way to break an install from a place nobody thinks to look. Anything else in the block is ignored with a warning naming it.

## Test plan

- [x] 502 tests
- [x] Verified on the release Mac against its real config: the setting is picked up, and `PATH` in that block is refused with a reason
- [x] A machine with no config at all is not an error, since `start_service` runs before setup has written anything