### PR TITLE
Keep the watcher's ML service in the watcher's process group

### DIFF
--- a/immich_accelerator/__main__.py
+++ b/immich_accelerator/__main__.py
@@ -1907,9 +1907,14 @@ def _signal_service(pid: int, sig: int, name: str = "") -> None:
 
     Services have children that must go with them: the worker runs several
     processes and spawns ffmpeg and exiftool, and a uvicorn engine can fork
-    workers. start_service and start_dashboard pass start_new_session, so
-    everything this supervisor spawns is a session leader, and a session
-    leader's process group can only be joined by its own descendants.
+    workers. start_service and start_dashboard pass start_new_session, so a
+    service that owns its session is a session leader, and a session leader's
+    process group can only be joined by its own descendants.
+
+    An ML service started by the watcher is the exception: it shares the
+    watcher's process group on purpose, so both tests below fail for it and it
+    is signalled by pid. That is what we want — it has no children to sweep,
+    and its group is the watcher's own.
 
     A pid can also be one we adopted rather than spawned — read_pid falls back
     to a process scan for the worker, adopt_live_ml and start_dashboard adopt a
@@ -2614,8 +2619,29 @@ def ensure_media_ready(config: dict) -> bool:
     return False
 
 
-def start_service(name: str, cmd: list[str], env: dict, cwd: str) -> int:
-    """Start a background service and track its PID. Returns PID."""
+# True only inside `immich-accelerator watch`. The watcher supervises the ML
+# service it starts, so ML stays in the watcher's process group and ends with
+# it. Every other entry point starts ML to outlive the command that asked for
+# it, which is why `start` from a terminal keeps its own session. Set once, at
+# the top of cmd_watch, and never cleared: a process runs one command.
+_SUPERVISING_ML = False
+
+
+def start_service(
+    name: str, cmd: list[str], env: dict, cwd: str, *, own_session: bool = True
+) -> int:
+    """Start a background service and track its PID. Returns PID.
+
+    own_session=True gives the service its own session, so it outlives the
+    command that started it. `immich-accelerator start` needs that: measured on
+    macOS 26.3, a service left in the caller's process group dies when the
+    terminal that ran the command closes, while one in its own session does not.
+
+    Pass own_session=False only for a service whose lifetime belongs to its
+    supervisor. It then shares the supervisor's process group, which is what
+    lets launchd's job cleanup — and a terminal hangup, for a watcher run by
+    hand — reach the service as well as the supervisor.
+    """
     LOG_DIR.mkdir(parents=True, exist_ok=True)
     log_file = LOG_DIR / f"{name}.log"
     cap_log(log_file)  # don't inherit a giant log across a (re)start
@@ -2627,7 +2653,7 @@ def start_service(name: str, cmd: list[str], env: dict, cwd: str) -> int:
             env=env,
             stdout=fh,
             stderr=subprocess.STDOUT,
-            start_new_session=True,
+            start_new_session=own_session,
         )
     except Exception:
         fh.close()
@@ -4551,7 +4577,9 @@ def _start_ml_preferred(config: dict):
             return None, None, False
         log.info("Starting ML service (%s)...", label)
         try:
-            pid = start_service("ml", cmd, senv, cwd)
+            pid = start_service(
+                "ml", cmd, senv, cwd, own_session=not _SUPERVISING_ML
+            )
             return pid, label, is_native
         except RuntimeError:
             log.warning("  %s failed to start", label)
@@ -4626,7 +4654,12 @@ def _ml_verify_or_fallback(config: dict, pid: int, engine: str):
         cmd, cwd, senv = venv
         log.info("Starting ML service (Python venv)...")
         try:
-            return start_service("ml", cmd, senv, cwd), "Python venv"
+            return (
+                start_service(
+                    "ml", cmd, senv, cwd, own_session=not _SUPERVISING_ML
+                ),
+                "Python venv",
+            )
         except RuntimeError:
             log.warning("  Python venv failed to start")
     return None, None
@@ -5880,9 +5913,12 @@ def _watch_without_worker(config: dict) -> str | None:
     """
     log.info("Watching ML-only service (Ctrl+C to stop)...")
 
-    # `brew services stop`/`restart` send SIGTERM to this watcher, but ml/
-    # dashboard run detached (own session) and would survive — trap the
-    # signal and stop them before exiting, matching cmd_watch's behavior.
+    # `brew services stop`/`restart` send SIGTERM to this watcher. The
+    # dashboard runs detached (own session) and would survive; an ML this
+    # watcher started shares its process group and would be swept by launchd,
+    # but only after this process exits, and an adopted ML is detached like the
+    # dashboard. Trap the signal and stop them before exiting, matching
+    # cmd_watch's behavior.
     def _graceful_stop(signum, _frame):
         log.info("Received signal %d, stopping services...", signum)
         try:
@@ -5970,6 +6006,8 @@ def cmd_watch(_args):
     hands back here when the "worker" component is toggled, so switching it
     takes effect on a running watcher instead of at the next restart.
     """
+    global _SUPERVISING_ML
+    _SUPERVISING_ML = True
     while True:
         config = load_config()
         if _component_enabled("worker", config):
@@ -6052,9 +6090,12 @@ def _watch_worker(config: dict) -> str | None:
         )
 
     # `brew services stop`/`restart` send SIGTERM to this watcher, but the
-    # worker/ML/dashboard run detached (own session) and would survive — so a
-    # plain stop/restart left them running (#81). Trap the signal and stop the
-    # children before exiting, so the service lifecycle works as expected.
+    # worker and dashboard run detached (own session) and would survive — so a
+    # plain stop/restart left them running (#81). An ML this watcher started
+    # shares its process group, but launchd only sweeps that group after this
+    # process exits, and an adopted ML is detached like the rest. Trap the
+    # signal and stop the children before exiting, so the service lifecycle
+    # works as expected.
     def _graceful_stop(signum, _frame):
         log.info("Received signal %d, stopping services...", signum)
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,11 @@ def no_real_machine_reads(monkeypatch):
     monkeypatch.setattr(m, "_ml_ping", lambda *a, **k: False)
     monkeypatch.setattr(m, "ml_port_state", lambda *a, **k: m.PORT_FREE)
     monkeypatch.setattr(m, "port_in_use", lambda *a, **k: False)
+    # cmd_watch claims the supervisor role by setting this and never clears it,
+    # because a process runs one command. A test process runs hundreds, so a
+    # test that drives cmd_watch would otherwise leave every later test
+    # believing it supervises the ML service.
+    monkeypatch.setattr(m, "_SUPERVISING_ML", m._SUPERVISING_ML)
     yield
 
 

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -972,7 +972,7 @@ class TestStartMlService:
 
         started = []
 
-        def fake_start(name, cmd, env, cwd):
+        def fake_start(name, cmd, env, cwd, **kwargs):
             started.append(cmd[0])
             return 222
 

--- a/tests/test_service_recovery.py
+++ b/tests/test_service_recovery.py
@@ -1016,10 +1016,12 @@ class TestAdoptionRunsBeforeStarting:
 
 
 class TestSpawnedServicesLeadTheirOwnSession:
-    """_signal_service decides by session leadership, so everything we spawn has
-    to be a session leader or its children stop going with it. Checked on a live
-    install for worker, ml and dashboard; this keeps start_new_session from
-    being dropped from start_service without anything noticing."""
+    """_signal_service decides by session leadership, so a service that owns its
+    session has to actually lead one or its children stop going with it. Checked
+    on a live install for worker, ml and dashboard; this keeps start_new_session
+    from being dropped from start_service without anything noticing.
+
+    A supervised ML service is the deliberate exception, covered below."""
 
     def test_start_service_leaves_a_session_leader(self, tmp_data_dir):
         with patch.object(m.time, "sleep"):  # skip the liveness pause
@@ -1028,6 +1030,87 @@ class TestSpawnedServicesLeadTheirOwnSession:
             assert os.getsid(pid) == pid
         finally:
             os.kill(pid, 9)
+
+    def test_a_supervised_service_stays_in_our_group(self, tmp_data_dir):
+        """own_session=False is the whole mechanism: the service has to end up in
+        the caller's process group, because that is the group launchd sweeps when
+        the job it manages dies."""
+        with patch.object(m.time, "sleep"):
+            pid = m.start_service(
+                "ml", ["/bin/sleep", "30"], dict(os.environ), "/tmp",
+                own_session=False,
+            )
+        try:
+            assert os.getpgid(pid) == os.getpgrp()
+            assert os.getsid(pid) != pid
+        finally:
+            os.kill(pid, 9)
+
+
+class TestTheWatcherKeepsMlInItsOwnProcessGroup:
+    """An ML service started with its own session survives the watcher dying,
+    keeps port 3003, and blocks the replacement — measured on macOS 26.3, where
+    the replacement logs EADDRINUSE and the old engine is never signalled at
+    all. Left in the watcher's group it is swept with the job. Every other
+    entry point still detaches, because a service started by `start` from a
+    terminal must survive that terminal closing.
+    """
+
+    CFG = {"ml_dir": "/ml", "ml_port": 3003}
+    NATIVE = (["nbin", "serve", "3003"], "/bundle", {})
+    VENV = (["py", "-m", "src.main"], "/ml", {})
+
+    def _spawn(self, supervising, healthy=True):
+        calls = []
+
+        def fake_start(name, cmd, env, cwd, *, own_session=True):
+            calls.append((cmd[0], own_session))
+            return 111
+
+        with patch.object(m, "_SUPERVISING_ML", supervising), patch.object(
+            m, "_native_ml_spec", return_value=self.NATIVE
+        ), patch.object(m, "_venv_ml_spec", return_value=self.VENV), patch.object(
+            m, "start_service", side_effect=fake_start
+        ), patch.object(m, "_ml_healthy", return_value=healthy), patch.object(
+            m, "kill_pid", return_value=True
+        ), patch.object(m, "wait_for_port_free", return_value=True), patch.object(
+            m, "ml_port_state", return_value=m.PORT_FREE
+        ):
+            m._start_ml_service(dict(self.CFG))
+        return calls
+
+    def test_the_watcher_supervises_the_engine_it_starts(self):
+        assert self._spawn(supervising=True) == [("nbin", False)]
+
+    def test_every_other_caller_leaves_the_engine_detached(self):
+        assert self._spawn(supervising=False) == [("nbin", True)]
+
+    def test_the_fallback_engine_follows_the_same_rule(self):
+        """_ml_verify_or_fallback starts the venv after native fails its health
+        check. Missing it would leave the bug on the fallback path only."""
+        assert self._spawn(supervising=True, healthy=False) == [
+            ("nbin", False),
+            ("py", False),
+        ]
+
+    def test_watch_is_what_claims_the_role(self):
+        """Nothing else may set the flag, so the claim has to come from entering
+        the watch command, and it has to be set before the loop starts anything."""
+        assert m._SUPERVISING_ML is False, "must default to detached"
+        seen = []
+
+        def loop(_config):
+            seen.append(m._SUPERVISING_ML)
+            return None  # not _SWITCH, so cmd_watch returns
+
+        with patch.object(m, "_SUPERVISING_ML", False), patch.object(
+            m, "load_config", return_value={}
+        ), patch.object(m, "_component_enabled", return_value=False), patch.object(
+            m, "_watch_without_worker", side_effect=loop
+        ):
+            m.cmd_watch(None)
+        assert seen == [True]
+        assert m._SUPERVISING_ML is False, "patch.object must have restored it"
 
 
 class TestTheGroupIsSignalledOnlyWhenWeLeadTheSession:


### PR DESCRIPTION
The watcher starts the ML service with `start_new_session=True`, which puts it in its own session and therefore its own process group. launchd sweeps the job's process group when the job dies, so a session of its own is exactly what takes the ML service out of that sweep. The watcher's SIGTERM handler covers a clean `brew services stop`, but any exit that skips the handler — launchd's SIGKILL after the stop grace period, a crash, `kickstart -k` — leaves the engine running and holding the ML port.

A healthy orphan is picked up again by `adopt_live_ml`. A wedged one is not, and that is the case this fixes.

## Reproducing it

`immich-accelerator watch` under a LaunchAgent, ML on port 3997, isolated from the machine's own install with `HOME`. On 1.13.0 (0dfb1ed):

```
watcher=15264  ml=15219   pgid 15264 vs 15219   ml stat=Ss

kill -STOP <ml>            # wedged: holds the port, answers nothing
kill -KILL <watcher>       # launchd restarts the watcher

after 90s:
  wedged ml alive? YES  stat=Ts
  listener: 15219        (still the wedged one)
  ping: no answer
  watcher log: nothing about the port
```

The ML service stays down until someone intervenes.

Same test with this change:

```
watcher=15897  ml=15917   pgid 15897 for both   ml stat=S

kill -STOP <ml>
kill -KILL <watcher>

  wedged ml alive? no
  new listener: 16078 after 7.6s
  ping: pong
  listeners on the port: 1
```

## The change

`start_service` takes `own_session`, defaulting to `True`. The watcher passes `False` for the ML service; nothing else changes.

`start_new_session=True` is correct for every other caller and this does not remove it. On a real PTY, a service left in the caller's process group is killed when the terminal closes and one in its own session is not, which is what `immich-accelerator start` needs:

```
spawned from a PTY, terminal then closed:   own session -> alive,  caller's group -> dead
spawned from a PTY-less channel, ended:     own session -> alive,  caller's group -> alive
```

Scoped to the ML service. The worker spawns ffmpeg and exiftool and needs its own group to signal, and it already has an orphan sweep in `_kill_all_worker_processes`; the ML service has neither. The dashboard and the one-time model download keep their own sessions.

`_signal_service` needs no change. A supervised ML service fails `_group_leader_is_ours` (the watcher's command line is not ML-shaped) and fails the session-leader test, so it is signalled by pid — which reaches everything there is, since neither engine has children.

## Measurements

macOS 26.3, M1, 8 GB. LaunchAgent plist identical to the rendered `homebrew.mxcl.immich-accelerator.plist` except for `Label` and `ProgramArguments`, bootstrapped into `gui/$UID`. The port is bound without `SO_REUSEADDR`, so any `EADDRINUSE` is real contention rather than `TIME_WAIT`.

Both real engines, 40 concurrent `/ping` applied before each action:

| engine | own session | action | engine dead after | port free after | replacement |
|---|---|---|---|---|---|
| native | yes (today) | SIGKILL watcher | never | never | `POSIXErrorCode 48: Address already in use` |
| venv | yes (today) | SIGKILL watcher | never | never | `[Errno 48] address already in use` |
| native | no | SIGKILL watcher | 0.3s | — | bound |
| native | no | `kickstart -k` | 0.3s | — | bound |
| native | no | `bootout` | 0.3s | 0.4s | port released |
| venv | no | SIGKILL watcher | 0.3–26.4s | 0.3s | bound |
| venv | no | `kickstart -k` | 0.7s | 0.3s | bound |
| venv | no | `bootout` | 0.7s | 0.3s | port released |
| venv | no | SIGKILL watcher, 253 sockets held open | 0.6s | 0.3s | bound |

Neither engine has descendants: `pgrep -P` is empty idle and under load. The venv engine's process can take up to 26s to exit while it unloads models, but it closes the listening socket first, so the port came back in 0.3s in every run.

launchd's post-exit sweep of the job's process group is a single SIGTERM with no escalation. A synthetic child that installs a SIGTERM handler and never exits survived all of SIGKILL-the-head, `kickstart -k` and `bootout`, still holding the port five minutes later. Neither engine does that: the native engine installs no signal handler and exits in 0.28s, and the venv engine's uvicorn shutdown always completed.

Against the patched watcher, on the real LaunchAgent:

- three crash/recovery cycles: old engine gone in 0.3s each time, one listener, `pong`, and the old and new engines were never resident together
- real Ctrl-C on a real PTY: watcher and ML both gone in 3.2s, no listener left
- `immich-accelerator start`: ML still gets its own session (`getsid == pid`, reparented to 1) and survives the command exiting

`pytest -m "not slow"`: 468 passed, 1 skipped. Reverting either half of the change turns the new tests red — the real-process test catches `start_new_session` going back to a constant, and the plumbing tests catch the watcher passing the wrong value.

## Not addressed here

- ML started by `immich-accelerator start` while the watcher is down is still detached and still outlives a watcher that is killed. That is unchanged behaviour. Making `start` delegate to launchd would mean reproducing Homebrew's `gui`/`user`/`system` domain selection, and getting that wrong breaks fresh installs, so it belongs in its own change.
- A watcher restart now restarts the ML service instead of adopting it. For the native engine that is a 0.3s exit and a cold start; that trade is the point of the change, but it is a behaviour change worth naming.
- Separately, `_venv_ml_spec` does not pass `ml_port` to the Python engine, which reads `ML_PORT` from the environment and otherwise defaults to 3003. An install with a non-default `ml_port` runs the venv engine on the wrong port. Found while testing this; not touched here.
