### PR TITLE
Keep the hvc1 tag when hardware encoding is off

### DIFF
--- a/immich_accelerator/ffmpeg-wrapper.sh
+++ b/immich_accelerator/ffmpeg-wrapper.sh
@@ -85,13 +85,16 @@ for ((i=0; i<${#ARGS[@]}; i++)); do
                 continue
                 ;;
             hevc|libx265)
+                # Before the switch: the output is HEVC either way, and the
+                # hvc1 tag below is about the container, not about which
+                # encoder produced the stream.
+                USE_HEVC=true
                 if [[ "$HW_VIDEO" != true ]]; then
                     NEW_ARGS+=("$arg" "$next"); ((i++)); continue
                 fi
                 NEW_ARGS+=("$arg" "hevc_videotoolbox")
                 ((i++))
                 USE_HW_ENCODER=true
-                USE_HEVC=true
                 continue
                 ;;
         esac

--- a/tests/test_fresh_install.py
+++ b/tests/test_fresh_install.py
@@ -1998,6 +1998,29 @@ class TestHardwareEncodingCanBeTurnedOff:
             )
             assert "h264_videotoolbox" in out, f"{value!r} should leave it on"
 
+    def test_hevc_still_gets_the_hvc1_tag_with_the_switch_off(self, tmp_path):
+        """hev1 (ffmpeg's default) stores parameter sets in-band and Apple's
+        decoder rejects it, so the wrapper injects hvc1 when the caller did not.
+        That is a property of the output container rather than of the encoder,
+        and libx265 defaults to hev1 as well."""
+        out = self._run(
+            tmp_path,
+            ["-i", "in.mov", "-c:v", "hevc", "out.mp4"],
+            env={"IMMICH_ACCEL_HW_VIDEO": "0"},
+        )
+        assert "hevc_videotoolbox" not in out, "the switch must still be honoured"
+        assert "hvc1" in out
+
+    def test_a_tag_the_caller_passed_is_still_left_alone(self, tmp_path):
+        """Immich passes -tag:v hvc1 itself for an HEVC target, so the injection
+        is a fallback and must not add a second tag."""
+        out = self._run(
+            tmp_path,
+            ["-i", "in.mov", "-c:v", "hevc", "-tag:v", "hvc1", "out.mp4"],
+            env={"IMMICH_ACCEL_HW_VIDEO": "0"},
+        )
+        assert out.count("hvc1") == 1, out
+
 
 class TestEncodingSwitches:
     """The `encoding` command, which is what the Settings switch calls.


### PR DESCRIPTION
The wrapper injects `-tag:v hvc1` for HEVC output the caller did not tag, because hev1 (ffmpeg's default) stores parameter sets in-band and Apple's decoder rejects it. libx265 defaults to hev1 as well, so that reason does not change with the encoder.

The switch added in 1.14.0 returns from the `hevc|libx265` branch before `USE_HEVC=true`, so with `IMMICH_ACCEL_HW_VIDEO=0` the injection never runs:

```bash
hevc|libx265)
    if [[ "$HW_VIDEO" != true ]]; then
        NEW_ARGS+=("$arg" "$next"); ((i++)); continue   # <- returns here
    fi
    ...
    USE_HEVC=true
```

Until the switch existed there was only one HEVC path, so `USE_HEVC` was equivalent to "the output is HEVC", which is what the tag block below means to ask. This sets the flag before the early return and leaves the remap gated on the switch, so software encoding stays software.

Measured with the released 1.14.0 wrapper on an M1, encoding a 1s clip through it:

| | `codec_tag_string` |
|---|---|
| `-c:v hevc`, `IMMICH_ACCEL_HW_VIDEO=0` | `hev1` |
| `-c:v hevc`, switch on | `hvc1` |

**How much this matters:** not much. Immich passes `-tag:v hvc1` itself whenever the target codec is HEVC (`dist/utils/media.js`, `isHvc`), so the injection is the fallback for callers that do not. It is worth having consistent anyway: for an HEVC target it was the only difference between the two switch positions beyond the encoder itself, and the tag block reads as though it covers all HEVC output.

If you would rather the wrapper only compensate for its own remap — leaving a software encode byte-for-byte what Docker would have produced — then the current behaviour is the one you want and this can be closed. I could not tell from the code which you intended, since the comment gives the Apple-decoder reason rather than a remap-compensation one.

Two tests: HEVC with the switch off keeps the tag and still does not remap the encoder, and a tag the caller passed is not duplicated. The first fails on `main`.
