### PR TITLE
Read the mean SSIM in encode-compare, not the last frame

### DIFF
--- a/immich_accelerator/__main__.py
+++ b/immich_accelerator/__main__.py
@@ -6869,14 +6869,17 @@ def _ssim_against(ffmpeg: str, candidate: str, reference: str) -> float | None:
             [
                 ffmpeg,
                 "-hide_banner",
+                # The mean is in the filter's summary line, which ssim logs at
+                # info. error drops it, and stats_file=- writes the per-frame
+                # numbers to stdout, so the last "All:" would be the last frame.
                 "-loglevel",
-                "error",
+                "info",
                 "-i",
                 candidate,
                 "-i",
                 reference,
                 "-lavfi",
-                "[0:v][1:v]ssim=stats_file=-",
+                "[0:v][1:v]ssim",
                 "-f",
                 "null",
                 "-",
@@ -6887,8 +6890,10 @@ def _ssim_against(ffmpeg: str, candidate: str, reference: str) -> float | None:
         )
     except (OSError, subprocess.SubprocessError):
         return None
-    hit = re.findall(r"All:([0-9.]+)", r.stdout + r.stderr)
-    return float(hit[-1]) if hit else None
+    # Anchored on the summary line, so a per-frame number can never be read as
+    # the mean if the command above ever grows a stats file again.
+    hit = re.search(r"SSIM .*\bAll:([0-9.]+)", r.stdout + r.stderr)
+    return float(hit.group(1)) if hit else None
 
 
 # The encoding switches, and the variable each one sets. The names live here

--- a/tests/test_service_recovery.py
+++ b/tests/test_service_recovery.py
@@ -1747,13 +1747,44 @@ class TestEncodeCompare:
             )
         assert size == 0
 
-    def test_the_mean_ssim_is_the_last_one_reported(self):
-        """ffmpeg prints a line per frame and the summary last."""
-        out = "n:1 All:0.9 \nn:2 All:0.8 \nSSIM All:0.997649 (26.3)\n"
+    def test_the_ssim_command_asks_for_the_summary_and_nothing_else(self):
+        """The mean only exists in the filter's summary line, and ssim logs that
+        at info. Asking for error would drop it, and a stats file would leave
+        the per-frame numbers behind for the parser to mistake for the mean."""
         with patch.object(
-            m.subprocess, "run", return_value=MagicMock(stdout=out, stderr="")
+            m.subprocess, "run", return_value=MagicMock(stdout="", stderr="")
+        ) as run:
+            m._ssim_against("/bin/ffmpeg", "/a.mp4", "/b.mp4")
+        argv = run.call_args.args[0]
+        assert argv[argv.index("-loglevel") + 1] == "info"
+        assert "stats_file" not in argv[argv.index("-lavfi") + 1]
+
+    def test_the_mean_ssim_comes_from_the_summary_line(self):
+        """Real output at this log level, with the per-frame numbers a stats
+        file would have added, to show the parser cannot pick one of them."""
+        err = (
+            "[Parsed_ssim_0 @ 0x1] SSIM Y:0.871987 (8.927451) U:1.000000 (inf) "
+            "V:1.000000 (inf) All:0.914658 (10.688364)\n"
+        )
+        with patch.object(
+            m.subprocess,
+            "run",
+            return_value=MagicMock(stdout="n:1 All:0.9 \nn:2 All:1.0 \n", stderr=err),
         ):
-            assert m._ssim_against("/bin/ffmpeg", "/a.mp4", "/b.mp4") == 0.997649
+            assert m._ssim_against("/bin/ffmpeg", "/a.mp4", "/b.mp4") == 0.914658
+
+    def test_per_frame_numbers_alone_are_not_a_mean(self):
+        """What the old command actually produced: no summary, only frames. The
+        last one is the last frame, and a still or dark final frame reads as
+        near-perfect quality, so returning it is worse than returning nothing."""
+        with patch.object(
+            m.subprocess,
+            "run",
+            return_value=MagicMock(
+                stdout="n:1 All:0.9 \nn:2 All:1.000000 \n", stderr=""
+            ),
+        ):
+            assert m._ssim_against("/bin/ffmpeg", "/a.mp4", "/b.mp4") is None
 
     def test_unreadable_ssim_output_is_not_a_number(self):
         with patch.object(


### PR DESCRIPTION
`_ssim_against` is documented as the mean SSIM, and `cmd_encode_compare` uses it
as one: it prints it per encode and picks the `--quality` value whose SSIM is
closest to the software encode. What it returns is the SSIM of the **last frame**.

The command runs at `-loglevel error` with `ssim=stats_file=-`. The filter logs
its summary line, the one carrying the mean, at info, so `error` drops it;
`stats_file=-` then writes the per-frame numbers to stdout. `re.findall(r"All:...")`
finds only those, and `hits[-1]` is the final frame.

Dropping the stats file and asking for info leaves exactly one `All:` in the
output — the mean — and no per-frame stats to hold in memory. The regex is
anchored on the summary line so a per-frame number cannot be read as the mean if
a stats file ever comes back.

## What it costs

The error is in the flattering direction: a dark or still frame encodes almost
perfectly. A clip that ends on black — a fade out, a title card, a static last
shot — reports perfect quality for everything.

720p, 10s, ending on two seconds of black. jellyfin-ffmpeg 7.1.4 on an M1,
`h264_videotoolbox` against `libx264 -preset ultrafast -crf 23`, the tool's own
defaults:

| q:v | last frame | gap | mean | gap |
|---|---|---|---|---|
| stock x264 crf 23 | 1.000000 | — | 0.993480 | — |
| 59 | 1.000000 | 0.000000 | 0.989330 | 0.004150 |
| 65 | 1.000000 | 0.000000 | 0.991961 | **0.001519** |
| 75 | 1.000000 | 0.000000 | 0.995148 | 0.001668 |
| 85 | 1.000000 | 0.000000 | 0.997155 | 0.003675 |

Every gap is `0.000000`, and the tie-break is strict (`gap < best[0]`), so the
recommendation is the first value in `--quality` whatever the footage was: q:v 59,
the lowest quality in the sweep, where the mean says q:v 65.

Without the black tail the gaps do not collapse to zero, but they still sit in
the sixth decimal of a single frame. Same clip, black tail removed: gaps spanned
0.000006 to 0.000079 across the whole sweep, against 0.001811 to 0.005462 for
the mean.

## Tests

`test_the_mean_ssim_is_the_last_one_reported` passed because its fixture
contained a summary line the real command cannot produce at that log level. It is
replaced by three:

- one on the argv, which fails on the old command and needs no ffmpeg;
- one on the parser against real summary output, with per-frame lines present, to
  show it cannot pick one of them;
- one on per-frame numbers alone — what the old command actually produced — which
  now returns `None` rather than a frame's SSIM.

The first and third fail against the current `_ssim_against`.

## How this was checked

Reproduced on ffmpeg 6.1.1 (Linux) and on jellyfin-ffmpeg 7.1.4 (macOS arm64),
the build the accelerator ships. On the shipped build, a 4s clip of noise followed
by black, candidate encoded at `-crf 40`:

```
-loglevel error + stats_file=-   40 "All:" lines, last = 1.000000
-loglevel info,  no stats_file    1 "All:" line,        0.914658
[Parsed_ssim_0] SSIM Y:0.871987 U:1.000000 V:1.000000 All:0.914658 (10.688364)
```

The patched function was then run end to end against that build and returned
`0.914658`. Full local pytest: 393 passed, 1 skipped.

## Two things I noticed and did not touch

Both are your call, and neither belongs in this fix:

1. `hw_cpu, hw_wall = cpu, secs` is assigned unconditionally inside the sweep
   loop, so the closing "which finished sooner" and "how much cpu" lines describe
   the **last** q:v tried, not `best[1]`, the one just recommended. One line to
   fix, but it is a separate bug. Happy to send it separately, or fold it in here
   if you would rather have one PR.
2. `_STOCK_PRESET` is hardcoded to `ultrafast`. That is Immich's default, so the
   comment above it is right, but an install that changed the preset is not
   described by this tool.

And one question rather than a finding: if the SSIM figures in the 1.14.0 release
notes and `docs/usage.md` (software 0.961, hardware 0.980) came from this command,
they are last-frame values and would want re-measuring. I have no way to tell from
here.
