### PR TITLE
Report the timings of the q:v that encode-compare recommends

### DIFF
--- a/immich_accelerator/__main__.py
+++ b/immich_accelerator/__main__.py
@@ -7051,7 +7051,6 @@ def cmd_encode_compare(args):
 
         log.info("Hardware, VideoToolbox")
         best = None
-        hw_cpu = hw_wall = 0.0
         for q in args.quality:
             dest = str(Path(tmp) / f"vt{q}.mp4")
             secs, size, cpu = _encode_once(
@@ -7063,11 +7062,13 @@ def cmd_encode_compare(args):
             ssim = _ssim_against(ffmpeg, dest, src)
             log.info("  q:v %d", q)
             _report(secs, size, ssim, duration, cpu)
-            hw_cpu, hw_wall = cpu, secs
             if ssim is not None and stock_ssim is not None:
                 gap = abs(ssim - stock_ssim)
                 if best is None or gap < best[0]:
-                    best = (gap, q, ssim)
+                    # The timings travel with the setting they belong to. Held
+                    # outside the tuple they were whatever the last q:v in the
+                    # sweep happened to cost, which is not the one recommended.
+                    best = (gap, q, ssim, secs, cpu)
 
         log.info("")
         if best:
@@ -7086,17 +7087,20 @@ def cmd_encode_compare(args):
             # ultrafast, which is genuinely quick, so software often finishes one
             # file sooner. What hardware buys is the machine: it leaves the cores
             # for the other jobs and for the ML engine running beside it.
+            hw_wall, hw_cpu = best[3], best[4]
             if stock_wall and hw_wall:
                 faster = "software" if stock_wall < hw_wall else "hardware"
                 log.info(
-                    "On this file %s finished sooner (%.1fs against %.1fs).",
+                    "At q:v %d on this file, %s finished sooner "
+                    "(%.1fs against %.1fs).",
+                    best[1],
                     faster,
                     min(stock_wall, hw_wall),
                     max(stock_wall, hw_wall),
                 )
             if stock_cpu and hw_cpu:
                 log.info(
-                    "Hardware used %.1fs of cpu against %.1fs, so it leaves the "
+                    "It used %.1fs of cpu against %.1fs, so it leaves the "
                     "machine free for the other jobs and for machine learning.",
                     hw_cpu,
                     stock_cpu,

--- a/tests/test_service_recovery.py
+++ b/tests/test_service_recovery.py
@@ -1786,6 +1786,42 @@ class TestEncodeCompare:
         ):
             assert m._ssim_against("/bin/ffmpeg", "/a.mp4", "/b.mp4") is None
 
+    def test_the_timings_reported_belong_to_the_recommended_setting(self, tmp_path):
+        """The closing lines follow the recommendation, so they read as a
+        description of it. They have to come from the q:v that was recommended
+        and not from whichever one the sweep happened to try last, which is the
+        slowest and largest of them under the default --quality."""
+        video = tmp_path / "in.mov"
+        video.write_text("")
+        ffmpeg = tmp_path / "ffmpeg"
+        ffmpeg.write_text("")
+        args = argparse.Namespace(video=str(video), crf=23, quality=[59, 65, 75])
+        with patch.object(m.shutil, "which", return_value=str(ffmpeg)), patch.object(
+            m, "CONFIG_FILE", tmp_path / "absent.json"
+        ), patch.object(m, "_ffprobe_duration", return_value=10.0), patch.object(
+            m,
+            "_encode_once",
+            side_effect=[
+                (10.0, 1000, 20.0),  # stock
+                (1.0, 100, 2.0),  # q:v 59
+                (2.0, 200, 4.0),  # q:v 65, the one that will be recommended
+                (3.0, 300, 6.0),  # q:v 75, tried last
+            ],
+        ), patch.object(
+            m, "_ssim_against", side_effect=[0.99, 0.90, 0.989, 0.80]
+        ), patch.object(
+            m, "log"
+        ) as log:
+            m.cmd_encode_compare(args)
+        said = [c.args for c in log.info.call_args_list]
+        recommended = next(c for c in said if "Closest to the software" in c[0])
+        assert recommended[1] == 65
+        wall = next(c for c in said if "finished sooner" in c[0])
+        assert sorted(a for a in wall if isinstance(a, float)) == [2.0, 10.0]
+        assert 65 in wall, "the line does not say which q:v it describes"
+        cpu = next(c for c in said if "of cpu against" in c[0])
+        assert sorted(a for a in cpu if isinstance(a, float)) == [4.0, 20.0]
+
     def test_unreadable_ssim_output_is_not_a_number(self):
         with patch.object(
             m.subprocess, "run", return_value=MagicMock(stdout="", stderr="")


### PR DESCRIPTION
Follow-up to #160, from reading the same function. Independent of it: this one
is about the timings, not the SSIM.

`cmd_encode_compare` closes with three lines — which q:v came closest to the
software encode, then how the encoders compared on wall time and on cpu. Printed
together, the last two read as a description of the first.

`hw_cpu` and `hw_wall` are assigned on every iteration, while `best` is only
replaced when a q:v comes closer:

```python
            hw_cpu, hw_wall = cpu, secs                 # every iteration
            if ssim is not None and stock_ssim is not None:
                gap = abs(ssim - stock_ssim)
                if best is None or gap < best[0]:
                    best = (gap, q, ssim)               # only when closer
```

So the closing lines describe the **last** q:v that encoded, which under the
default `--quality` of `59 65 75 85` is always 85, whatever was recommended.

The direction is consistent rather than random: 85 is the highest quality in the
sweep, so the largest file and the longest encode. The recommended setting is
reported as slower and more cpu-hungry than it actually is — the opposite of what
those two lines exist to show.

Carrying the timings in `best` fixes it. The wall line now names the q:v it is
talking about, since not naming it is what let the mismatch sit unnoticed, and
the cpu line follows it and refers back to it. Say the word if you would rather
keep the original wording and take only the numeric fix.

The new test drives `cmd_encode_compare` with a sweep whose best q:v is not its
last, and asserts the reported figures belong to the recommended one. Against the
current code it fails with the last setting's numbers:

```
E       assert [3.0, 10.0] == [2.0, 10.0]
E         At index 0 diff: 3.0 != 2.0
```

Full local pytest: 394 passed, 1 skipped.

Still open from #160, in case it is useful to have in one place: `_STOCK_PRESET`
is hardcoded to `ultrafast`, so an install that changed Immich's preset is not
described by this tool; and if the SSIM figures in the 1.14.0 release notes and
`docs/usage.md` came from this command, they are last-frame values from before
#160 and would want re-measuring.
