### PR TITLE
Pin the Swift default-off set and truth words to Python

### DIFF
--- a/tests/test_release_hygiene.py
+++ b/tests/test_release_hygiene.py
@@ -181,6 +181,25 @@ def test_the_swift_preset_names_match_the_python_ones():
     for name, switches in mirror.items():
         assert switches == m.ENCODING_PRESETS[name], name
 
+    # The slice above stops at `encodingDefaultOff`, so the two things that
+    # decide how a switch reads are outside it: which switches default off,
+    # and the words the wrapper accepts as on and as off. Both were pinned by
+    # nothing, and emptying the set left the whole suite green while the pane
+    # would have shown hardware audio on by default and the CLI off.
+    default_off = re.search(r"encodingDefaultOff: Set<String> = \[(.*?)\]", model)
+    assert default_off, "could not parse StatusModel's default-off set; update this test"
+    mirrored_off = set(re.findall(r'"(\w+)"', default_off.group(1)))
+    assert mirrored_off == set(m._DEFAULT_OFF), f"StatusModel has {sorted(mirrored_off)}"
+
+    # The negated branch is written first, so the first list is the off words.
+    # Which list is which is the meaning; the order inside one is not.
+    words = [
+        set(re.findall(r'"([a-z0-9]+)"', group))
+        for group in re.findall(r'\[((?:\s*"[a-z0-9]+",?)+)\]\.contains\(value\)', model)
+    ]
+    assert len(words) == 2, "could not parse StatusModel's truth words; update this test"
+    assert words == [set(m._ENV_OFF), set(m._ENV_ON)], f"StatusModel has {words}"
+
     pane = (root / "menubar/Sources/AcceleratorBar/SettingsView.swift").read_text()
     listing = pane[pane.index("static let positions:"):pane.index("private var currentPosition")]
     names = set(re.findall(r'\("([a-z-]+)",\s*"', listing)) - {"custom"}


### PR DESCRIPTION
`test_the_swift_preset_names_match_the_python_ones` exists to stop the Swift mirror of the encoding settings drifting from the Python tables that define them. It slices `StatusModel.swift` from `"encodingPresets:"` up to `"encodingDefaultOff"`, so it stops literally at the boundary of the default-off set. Everything from there down was mirrored from Python and checked by nothing: `encodingDefaultOff` itself, and the two word lists hardcoded inside `encodingSwitchOn`, which are the Swift copies of `_ENV_OFF` and `_ENV_ON`.

Proven by mutation rather than by reading. Emptying `encodingDefaultOff` to `[]` and adding a bogus word `"nope"` to the off list leaves the whole suite green — 537 passed, no new failures. With that in place the Processing pane reports hardware audio as on by default while `cmd_encoding` and `ffmpeg-wrapper.sh` both say off, which is the drift this test was written to catch.

The check is extended in place rather than added alongside, since it is already the "the Swift mirror agrees with Python" test. It now also compares `encodingDefaultOff` against `_DEFAULT_OFF`, and the two lists in `encodingSwitchOn` against `_ENV_OFF` and `_ENV_ON`. Which of those two lists is which is the meaning, so that stays positional and the negated branch is written first; the order of the words inside one list is not, so they compare as sets and a pure reorder does not fail. Each parse asserts it found something and tells you to update the test if the Swift is restructured, following the convention the surrounding asserts already use, so a regex that stops matching fails loudly instead of passing on zero matches.

19 added lines in one file. Nothing outside `tests/` is touched.

## Verified

Each mutation applied to `StatusModel.swift` on its own, with `git checkout -- menubar` in between:

| Mutation | Result |
| --- | --- |
| clean tree | passes |
| `encodingDefaultOff` emptied to `[]` | fails |
| `"nope"` added to the off list | fails |
| `"yes"` changed to `"yeah"` in the on list | fails |
| off list reordered to `["no", "0", "false"]` | passes, correctly — same behaviour |
| `encodingDefaultOff` renamed | fails on the parse guard, not silently |

Full suite before and after: 537 passed, 5 skipped. Two failures in `TestDashboardDependenciesAreAvailable` are local to my checkout, where the `ml/` submodule is not initialised, and are unrelated to this change.
