### PR TITLE
Pin ps to LC_ALL=C when reading a process start time

### DIFF
--- a/immich_accelerator/__main__.py
+++ b/immich_accelerator/__main__.py
@@ -1743,13 +1743,26 @@ def load_config() -> dict:
 
 
 def _get_process_start_time(pid: int) -> str | None:
-    """Get process start time via ps. Used to detect PID reuse."""
+    """Get process start time via ps. Used to detect PID reuse.
+
+    LC_ALL=C is required, not cosmetic: ps formats lstart through the
+    caller's locale, so the same process reads back as "Sat Aug 22
+    23:07:37 2026" under C/en_US but "Sat 22 Aug 23:07:37 2026" under
+    en_AU/en_GB. Our writer and reader are frequently different processes
+    with different locales — launchd (brew services) passes no LANG at
+    all, while a Terminal session inherits the user's region — so an
+    unpinned locale makes read_pid see a start-time mismatch, conclude
+    the PID was reused, and delete a pidfile whose service is healthy.
+    Downstream that reports a running service as stopped, makes stop a
+    no-op that orphans it, and makes start try to spawn a duplicate.
+    """
     try:
         result = subprocess.run(
             ["ps", "-p", str(pid), "-o", "lstart="],
             capture_output=True,
             text=True,
             timeout=5,
+            env={**os.environ, "LC_ALL": "C"},
         )
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout.strip()

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -22,6 +22,7 @@ from immich_accelerator.__main__ import (
     write_pid,
     read_pid,
     kill_pid,
+    _get_process_start_time,
     detect_immich,
     _docker_is_running,
     _find_running_docker,
@@ -350,6 +351,38 @@ class TestPidManagement:
         ):
             result = read_pid("worker")
             assert result == current_pid
+
+    def test_start_time_is_locale_independent(self):
+        """ps formats lstart through the caller's locale, so an unpinned
+        locale makes the same live process read back differently depending
+        on who asked: "Sat Aug 22 23:07:37 2026" under C/en_US but "Sat 22
+        Aug 23:07:37 2026" under en_AU/en_GB. launchd (brew services)
+        passes no LANG while a Terminal inherits the user's region, so the
+        writer and the reader of a pidfile disagreed, read_pid called it a
+        reused PID, and deleted the pidfile of a healthy service."""
+        baseline = _get_process_start_time(os.getpid())
+        assert baseline, "ps gave no start time for our own pid"
+
+        for lang in ("en_AU.UTF-8", "en_GB.UTF-8", "en_US.UTF-8", "C"):
+            with patch.dict(os.environ, {"LANG": lang, "LC_TIME": lang}):
+                assert _get_process_start_time(os.getpid()) == baseline, (
+                    f"start time changed under LANG={lang} — the ps call "
+                    "is not pinned to a fixed locale"
+                )
+
+    def test_pidfile_survives_a_reader_in_a_different_locale(self, tmp_data_dir):
+        """End-to-end guard for the deletion: write the pidfile as one
+        process would, then read it back as a differently-localed process
+        (launchd vs Terminal). The pid must still resolve and the file must
+        still be there."""
+        current_pid = os.getpid()
+        with patch.dict(os.environ, {"LANG": "C", "LC_TIME": "C"}):
+            write_pid("worker", current_pid)
+
+        pid_file = tmp_data_dir["pid_dir"] / "worker.pid"
+        with patch.dict(os.environ, {"LANG": "en_AU.UTF-8", "LC_TIME": "en_AU.UTF-8"}):
+            assert read_pid("worker") == current_pid
+        assert pid_file.exists(), "a differently-localed reader deleted the pidfile"
 
     def test_kill_pid_returns_false_when_not_running(self, tmp_data_dir):
         assert kill_pid("worker") is False


### PR DESCRIPTION
## What this changes

`_get_process_start_time()` now runs `ps` with `LC_ALL=C`.

`ps` formats `lstart` through the caller's locale, so the same live process reads back differently depending on who asked:

| locale | `ps -p <pid> -o lstart=` |
|---|---|
| `C`, `en_US.UTF-8` | `Sat Aug 22 23:07:37 2026` |
| `en_AU.UTF-8`, `en_GB.UTF-8` | `Sat 22 Aug 23:07:37 2026` |

That string goes into the pidfile and is compared later to detect PID reuse — but the writer and the reader are usually **different processes with different locales**: launchd (`brew services`) passes no `LANG` at all, while a Terminal session inherits the user's region. So for anyone outside a month-first locale the comparison failed, `read_pid()` concluded the PID had been reused, and **deleted the pidfile of a perfectly healthy service**.

What that looks like to a user:

- `status` reports a running service as `stopped`
- `stop` becomes a no-op — the service is left orphaned, needing a manual `pkill`
- `start` tries to spawn a duplicate: `port 3003 is already in use` for ML, or a second worker

Reproduced on an `en_AU` Mac running 1.14.0 with Immich 3.1.0: `LANG=en_AU.UTF-8 immich-accelerator status` printed `ML service: stopped` **and deleted `ml.pid`**, while the engine was answering `/ping` with `pong` and serving CLIP/face/OCR requests. With the fix, the same command reports `running (PID 63300)` under both `en_AU` and `C`, repeatedly, and the pidfile survives.

The worker mostly hides this because `read_pid("worker")` falls back to `_adopt_live_worker()`; ML has no equivalent fallback, which is why ML is the visible casualty. I haven't touched that asymmetry — separate concern, happy to open an issue if you'd like it looked at.

Two regression tests added to `TestPidManagement`: one asserts the start time is stable across `LANG` values, one writes a pidfile in `C` and reads it back under `en_AU` and asserts the file still exists. Both fail without the `env=` line and pass with it (verified in both directions).

## Checklist

- [x] Ran `pytest -v -m "not slow"` locally — all tests pass (516 passed, 19 skipped)
- [x] Tested on a real Mac with the accelerator running (Apple Silicon, `en_AU`, accelerator 1.14.0 + Immich 3.1.0)
- [x] No unrelated changes bundled in

## Notes for review

- **One-time effect on upgrade:** pidfiles written in a non-C locale before this change will mismatch once after upgrading — exactly the same invalidation as before, so services get re-adopted or restarted and the next write is locale-independent. No user action needed.
- No `CHANGELOG.md` edit, per CONTRIBUTING. No `VERSION` bump — fork PRs are exempt from the `version-bump` job.
